### PR TITLE
Phase 2: structured errors, array helpers, typed config, wasm-opt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"       # Only publish on version tags, e.g. v1.2.3
 
+env:
+  # Pin binaryen version so optimisation output is reproducible.
+  BINARYEN_VERSION: version_119
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -33,6 +37,25 @@ jobs:
 
       - name: Build WASM targets
         run: npm run build
+
+      - name: Install binaryen wasm-opt (pinned release binary)
+        run: |
+          curl -sSfL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+            | sudo tar -xz -C /usr/local --strip-components=1 \
+                "binaryen-${BINARYEN_VERSION}/bin/wasm-opt"
+          wasm-opt --version
+
+      - name: Optimise WASM artefacts (-O3)
+        run: |
+          # Cargo.toml sets wasm-pack's wasm-opt to false to avoid a download
+          # flake during local dev builds. We re-optimise the release output
+          # here so the published bundle is properly minimised. -O3 typically
+          # shrinks wasm-bindgen output by 20-40%.
+          for target in web node bundler; do
+            wasm-opt -O3 \
+              "dist/${target}/centaur-technical-indicators_bg.wasm" \
+              -o "dist/${target}/centaur-technical-indicators_bg.wasm"
+          done
 
       - name: Publish to npm
         run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- **Error messages are now structured rather than panic strings.** Every fallible
+  Rust binding was rewritten from `.expect("Failed to calculate …")` to
+  `Result<T, JsValue>` with `JsError` carrying the upstream
+  `TechnicalIndicatorError::Display` message. The JS-side behavior is unchanged
+  on success and still throws on failure, but the thrown `Error.message` now
+  preserves the structured upstream text (e.g., `"Mismatched lengths: highs=5,
+  lows=4"`) instead of a generic `"Failed to calculate indicator"` panic string.
+  Zero `.expect()` calls remain in `src/*.rs`. Affects every binding across all
+  9 modules; total 86 call sites converted.
+- `index.d.ts`: `chartTrends.breakDownTrends` is now `@deprecated since 1.3.0`.
+  Use the new `breakDownTrendsWithConfig(prices, config)` instead. The positional
+  form is preserved for backwards compatibility and will be removed in a future
+  major release.
+- `index.d.ts`: `trendIndicators.bulk.volumePriceTrend` JSDoc gains a loud
+  `⚠️ Warning` block describing the silent first-volume drop that happens when
+  `volumes.length === prices.length`. No runtime change — only docs.
+
+### Added
+- `src/jsutil.rs`: internal helper module with `js_err`, `flat_to_array`,
+  `pair_to_array`, `triple_to_array`, `quintuple_to_array`, `pairs_to_array`,
+  `triples_to_array`, `quads_to_array`, `quintuples_to_array`. Compresses the
+  inline `Array::new()` / `push(&JsValue::from_f64(...))` boilerplate that was
+  duplicated across every binding.
+- `chartTrends.breakDownTrendsWithConfig(prices, config)`: new typed-config
+  variant of `breakDownTrends`. Takes a `TrendBreakConfig` object so soft/hard
+  thresholds and Durbin-Watson bounds cannot be accidentally transposed.
+- `index.d.ts`: new `TrendBreakConfig` interface mirroring the upstream Rust
+  struct with camelCase field names.
+
+### Performance
+- `publish.yml` runs `wasm-opt -O3` on the published WASM artefacts via a pinned
+  binaryen `version_119` binary download (no third-party GitHub Action). The
+  published bundle should be ~20-40% smaller. `Cargo.toml` still sets
+  `wasm-opt = false` to keep local builds fast and avoid CI download flakes
+  during everyday testing — only the publish step optimises.
+
 ---
 
 ## [1.2.2] - 2026-04-04

--- a/index.d.ts
+++ b/index.d.ts
@@ -501,6 +501,12 @@ export interface ChartTrends {
   /**
    * Segment the series into distinct trend ranges based on goodness-of-fit thresholds.
    * Uses Centaur Technical Indicators 1.0.0 TrendBreakConfig parameters.
+   *
+   * @deprecated since 1.3.0 — the 9-positional-argument form is easy to misorder
+   * (e.g., swapping soft/hard Durbin-Watson bounds). Use {@link ChartTrends.breakDownTrendsWithConfig}
+   * with a typed config object instead. This positional form is preserved for
+   * backwards compatibility and will be removed in a future major release.
+   *
    * @param prices Prices series.
    * @param maxOutliers Maximum number of outliers allowed before trend break.
    * @param softAdjRSquaredMinimum Soft minimum adjusted R-squared threshold.
@@ -525,6 +531,59 @@ export interface ChartTrends {
     hardDurbinWatsonMin: number,
     hardDurbinWatsonMax: number
   ): [number, number, number, number][];
+
+  /**
+   * Segment the series into distinct trend ranges using a typed config object.
+   * Equivalent to {@link ChartTrends.breakDownTrends} but with named fields,
+   * so soft/hard thresholds and Durbin-Watson bounds cannot be transposed.
+   *
+   * @param prices Prices series.
+   * @param config Goodness-of-fit thresholds; see {@link TrendBreakConfig}.
+   * @returns Array of [startIndex, endIndex, slope, intercept].
+   *
+   * @example
+   * chartTrends.breakDownTrendsWithConfig(prices, {
+   *   maxOutliers: 1,
+   *   softAdjRSquaredMinimum: 0.5,
+   *   hardAdjRSquaredMinimum: 0.25,
+   *   softRmseMultiplier: 2.0,
+   *   hardRmseMultiplier: 3.0,
+   *   softDurbinWatsonMin: 0.5,
+   *   softDurbinWatsonMax: 3.5,
+   *   hardDurbinWatsonMin: 0.25,
+   *   hardDurbinWatsonMax: 3.75,
+   * });
+   */
+  breakDownTrendsWithConfig(
+    prices: number[],
+    config: TrendBreakConfig
+  ): [number, number, number, number][];
+}
+
+/**
+ * Goodness-of-fit thresholds for {@link ChartTrends.breakDownTrendsWithConfig}.
+ * Mirrors the upstream Rust `TrendBreakConfig` struct, with camelCase field
+ * names matching the rest of this binding.
+ */
+export interface TrendBreakConfig {
+  /** Maximum number of outliers allowed before a trend break is forced. */
+  maxOutliers: number;
+  /** Soft minimum adjusted R-squared threshold. */
+  softAdjRSquaredMinimum: number;
+  /** Hard minimum adjusted R-squared threshold. */
+  hardAdjRSquaredMinimum: number;
+  /** Soft RMSE multiplier for trend breaks. */
+  softRmseMultiplier: number;
+  /** Hard RMSE multiplier for trend breaks. */
+  hardRmseMultiplier: number;
+  /** Soft minimum Durbin-Watson statistic. */
+  softDurbinWatsonMin: number;
+  /** Soft maximum Durbin-Watson statistic. */
+  softDurbinWatsonMax: number;
+  /** Hard minimum Durbin-Watson statistic. */
+  hardDurbinWatsonMin: number;
+  /** Hard maximum Durbin-Watson statistic. */
+  hardDurbinWatsonMax: number;
 }
 
 /**
@@ -1688,8 +1747,19 @@ export interface TrendIndicatorsBulk {
 
   /**
    * Rolling Volume Price Trend (VPT).
+   *
+   * ⚠️ **Warning — silent first-volume drop on same-length input.** If
+   * `volumes.length === prices.length`, this binding silently passes
+   * `volumes.slice(1)` to the upstream calculation, dropping `volumes[0]`.
+   * That matches the upstream Rust crate's convention (each `price[i]`
+   * is paired with the volume traded between `prices[i-1]` and `prices[i]`),
+   * but is easy to misread from JS: a naïvely-aligned same-length series
+   * will misalign by one sample without warning. The intended call shape
+   * is `volumes.length === prices.length - 1`.
+   *
    * @param prices Price series (length L).
-   * @param volumes Volume series (length L or L-1). If same length as prices, the first volume is skipped.
+   * @param volumes Volume series (length L-1 preferred; same-length L is
+   *   accepted but the first volume is silently dropped — see warning above).
    * @param previousVolumePriceTrend Seed VPT value.
    * @returns VPT values per step (length L-1).
    * @throws If lengths mismatch or empty.

--- a/index.js
+++ b/index.js
@@ -35,7 +35,23 @@ export const chartTrends = {
   peakTrend: wasm.chart_trends_peakTrend,
   valleyTrend: wasm.chart_trends_valleyTrend,
   overallTrend: wasm.chart_trends_overallTrend,
-  breakDownTrends: wasm.chart_trends_breakDownTrends
+  breakDownTrends: wasm.chart_trends_breakDownTrends,
+  // 1.3.0: typed-config variant that destructures `config` into the
+  // positional wasm call. The positional `breakDownTrends` above stays
+  // as-is for backwards compatibility.
+  breakDownTrendsWithConfig: (prices, config) =>
+    wasm.chart_trends_breakDownTrends(
+      prices,
+      config.maxOutliers,
+      config.softAdjRSquaredMinimum,
+      config.hardAdjRSquaredMinimum,
+      config.softRmseMultiplier,
+      config.hardRmseMultiplier,
+      config.softDurbinWatsonMin,
+      config.softDurbinWatsonMax,
+      config.hardDurbinWatsonMin,
+      config.hardDurbinWatsonMax,
+    ),
 };
 
 export const correlationIndicators = {

--- a/index.node.js
+++ b/index.node.js
@@ -41,6 +41,19 @@ export const chartTrends = {
   valleyTrend: wasm.chart_trends_valleyTrend,
   overallTrend: wasm.chart_trends_overallTrend,
   breakDownTrends: wasm.chart_trends_breakDownTrends,
+  breakDownTrendsWithConfig: (prices, config) =>
+    wasm.chart_trends_breakDownTrends(
+      prices,
+      config.maxOutliers,
+      config.softAdjRSquaredMinimum,
+      config.hardAdjRSquaredMinimum,
+      config.softRmseMultiplier,
+      config.hardRmseMultiplier,
+      config.softDurbinWatsonMin,
+      config.softDurbinWatsonMax,
+      config.hardDurbinWatsonMin,
+      config.hardDurbinWatsonMax,
+    ),
 };
 
 export const correlationIndicators = {

--- a/index.web.js
+++ b/index.web.js
@@ -32,7 +32,20 @@ export const chartTrends = {
   peakTrend: wasm.chart_trends_peakTrend,
   valleyTrend: wasm.chart_trends_valleyTrend,
   overallTrend: wasm.chart_trends_overallTrend,
-  breakDownTrends: wasm.chart_trends_breakDownTrends
+  breakDownTrends: wasm.chart_trends_breakDownTrends,
+  breakDownTrendsWithConfig: (prices, config) =>
+    wasm.chart_trends_breakDownTrends(
+      prices,
+      config.maxOutliers,
+      config.softAdjRSquaredMinimum,
+      config.hardAdjRSquaredMinimum,
+      config.softRmseMultiplier,
+      config.hardRmseMultiplier,
+      config.softDurbinWatsonMin,
+      config.softDurbinWatsonMax,
+      config.hardDurbinWatsonMin,
+      config.hardDurbinWatsonMax,
+    ),
 };
 
 export const correlationIndicators = {

--- a/src/candle_indicators.rs
+++ b/src/candle_indicators.rs
@@ -1,3 +1,7 @@
+use crate::jsutil::{
+    flat_to_array, js_err, quintuple_to_array, quintuples_to_array, triple_to_array,
+    triples_to_array,
+};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -8,18 +12,15 @@ pub fn candle_single_moving_constant_envelopes(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     difference: f64,
-) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::moving_constant_envelopes(
-        &prices,
-        constant_model_type.into(),
-        difference,
-    )
-    .expect("Failed to calculate moving constant envelopes");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+) -> Result<Array, JsValue> {
+    let triple =
+        centaur_technical_indicators::candle_indicators::single::moving_constant_envelopes(
+            &prices,
+            constant_model_type.into(),
+            difference,
+        )
+        .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_mcginleyDynamicEnvelopes)]
@@ -27,18 +28,15 @@ pub fn candle_single_mcginley_dynamic_envelopes(
     prices: Vec<f64>,
     difference: f64,
     previous_mcginley_dynamic: f64,
-) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_envelopes(
-        &prices,
-        difference,
-        previous_mcginley_dynamic,
-    )
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+) -> Result<Array, JsValue> {
+    let triple =
+        centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_envelopes(
+            &prices,
+            difference,
+            previous_mcginley_dynamic,
+        )
+        .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_movingConstantBands)]
@@ -47,19 +45,15 @@ pub fn candle_single_moving_constant_bands(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
-) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::moving_constant_bands(
+) -> Result<Array, JsValue> {
+    let triple = centaur_technical_indicators::candle_indicators::single::moving_constant_bands(
         &prices,
         constant_model_type.into(),
         deviation_model.into(),
         deviation_multiplier,
     )
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+    .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_mcginleyDynamicBands)]
@@ -68,19 +62,15 @@ pub fn candle_single_mcginley_dynamic_bands(
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
     previous_mcginley_dynamic: f64,
-) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_bands(
+) -> Result<Array, JsValue> {
+    let triple = centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_bands(
         &prices,
         deviation_model.into(),
         deviation_multiplier,
         previous_mcginley_dynamic,
     )
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+    .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_ichimokuCloud)]
@@ -91,8 +81,8 @@ pub fn candle_single_ichimoku_cloud(
     conversion_period: usize,
     base_period: usize,
     span_b_period: usize,
-) -> Array {
-    let (a, b, base, conv, displaced_close) = centaur_technical_indicators::candle_indicators::single::ichimoku_cloud(
+) -> Result<Array, JsValue> {
+    let quintuple = centaur_technical_indicators::candle_indicators::single::ichimoku_cloud(
         &highs,
         &lows,
         &close,
@@ -100,25 +90,17 @@ pub fn candle_single_ichimoku_cloud(
         base_period,
         span_b_period,
     )
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(a));
-    arr.push(&JsValue::from_f64(b));
-    arr.push(&JsValue::from_f64(base));
-    arr.push(&JsValue::from_f64(conv));
-    arr.push(&JsValue::from_f64(displaced_close));
-    arr
+    .map_err(js_err)?;
+    Ok(quintuple_to_array(quintuple))
 }
 
 #[wasm_bindgen(js_name = candle_single_donchianChannels)]
-pub fn candle_single_donchian_channels(highs: Vec<f64>, lows: Vec<f64>) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::donchian_channels(&highs, &lows)
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+pub fn candle_single_donchian_channels(highs: Vec<f64>, lows: Vec<f64>) -> Result<Array, JsValue> {
+    let triple = centaur_technical_indicators::candle_indicators::single::donchian_channels(
+        &highs, &lows,
+    )
+    .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_keltnerChannel)]
@@ -129,8 +111,8 @@ pub fn candle_single_keltner_channel(
     constant_model_type: crate::ConstantModelType,
     atr_constant_model_type: crate::ConstantModelType,
     multiplier: f64,
-) -> Array {
-    let (l, m, u) = centaur_technical_indicators::candle_indicators::single::keltner_channel(
+) -> Result<Array, JsValue> {
+    let triple = centaur_technical_indicators::candle_indicators::single::keltner_channel(
         &highs,
         &lows,
         &close,
@@ -138,12 +120,8 @@ pub fn candle_single_keltner_channel(
         atr_constant_model_type.into(),
         multiplier,
     )
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(l));
-    arr.push(&JsValue::from_f64(m));
-    arr.push(&JsValue::from_f64(u));
-    arr
+    .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = candle_single_supertrend)]
@@ -153,7 +131,7 @@ pub fn candle_single_supertrend(
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     multiplier: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::candle_indicators::single::supertrend(
         &highs,
         &lows,
@@ -161,7 +139,7 @@ pub fn candle_single_supertrend(
         constant_model_type.into(),
         multiplier,
     )
-    .expect("Failed to calculate supertrend")
+    .map_err(js_err)
 }
 
 // ------------- BULK -------------
@@ -171,23 +149,15 @@ pub fn candle_bulk_moving_constant_envelopes(
     constant_model_type: crate::ConstantModelType,
     difference: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::moving_constant_envelopes(
         &prices,
         constant_model_type.into(),
         difference,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_mcginleyDynamicEnvelopes)]
@@ -196,23 +166,15 @@ pub fn candle_bulk_mcginley_dynamic_envelopes(
     difference: f64,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::mcginley_dynamic_envelopes(
         &prices,
         difference,
         previous_mcginley_dynamic,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_movingConstantBands)]
@@ -222,7 +184,7 @@ pub fn candle_bulk_moving_constant_bands(
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::moving_constant_bands(
         &prices,
         constant_model_type.into(),
@@ -230,16 +192,8 @@ pub fn candle_bulk_moving_constant_bands(
         deviation_multiplier,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_mcginleyDynamicBands)]
@@ -249,7 +203,7 @@ pub fn candle_bulk_mcginley_dynamic_bands(
     deviation_multiplier: f64,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::mcginley_dynamic_bands(
         &prices,
         deviation_model.into(),
@@ -257,16 +211,8 @@ pub fn candle_bulk_mcginley_dynamic_bands(
         previous_mcginley_dynamic,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_ichimokuCloud)]
@@ -277,7 +223,7 @@ pub fn candle_bulk_ichimoku_cloud(
     conversion_period: usize,
     base_period: usize,
     span_b_period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::ichimoku_cloud(
         &highs,
         &lows,
@@ -286,33 +232,21 @@ pub fn candle_bulk_ichimoku_cloud(
         base_period,
         span_b_period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (a, b, base, conv, displaced_close) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(a));
-        inner.push(&JsValue::from_f64(b));
-        inner.push(&JsValue::from_f64(base));
-        inner.push(&JsValue::from_f64(conv));
-        inner.push(&JsValue::from_f64(displaced_close));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(quintuples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_donchianChannels)]
-pub fn candle_bulk_donchian_channels(highs: Vec<f64>, lows: Vec<f64>, period: usize) -> Array {
-    let data = centaur_technical_indicators::candle_indicators::bulk::donchian_channels(&highs, &lows, period)
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+pub fn candle_bulk_donchian_channels(
+    highs: Vec<f64>,
+    lows: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::candle_indicators::bulk::donchian_channels(
+        &highs, &lows, period,
+    )
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_keltnerChannel)]
@@ -324,7 +258,7 @@ pub fn candle_bulk_keltner_channel(
     atr_constant_model_type: crate::ConstantModelType,
     multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::keltner_channel(
         &highs,
         &lows,
@@ -334,16 +268,8 @@ pub fn candle_bulk_keltner_channel(
         multiplier,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (l, m, u) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(l));
-        inner.push(&JsValue::from_f64(m));
-        inner.push(&JsValue::from_f64(u));
-        outer.push(&inner);
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = candle_bulk_supertrend)]
@@ -354,7 +280,7 @@ pub fn candle_bulk_supertrend(
     constant_model_type: crate::ConstantModelType,
     multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::supertrend(
         &highs,
         &lows,
@@ -363,10 +289,6 @@ pub fn candle_bulk_supertrend(
         multiplier,
         period,
     )
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for v in data {
-        outer.push(&JsValue::from_f64(v));
-    }
-    outer
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/chart_trends.rs
+++ b/src/chart_trends.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{js_err, pair_to_array, pairs_to_array, quads_to_array};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -6,69 +7,55 @@ use wasm_bindgen::JsValue;
 
 // peaks: Vec<(f64, usize)> -> Array<[value, index]>
 #[wasm_bindgen(js_name = chart_trends_peaks)]
-pub fn chart_trends_peaks(prices: Vec<f64>, period: usize, closest_neighbor: usize) -> Array {
-    let pairs = centaur_technical_indicators::chart_trends::peaks(&prices, period, closest_neighbor)
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (val, idx) in pairs {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(val));
-        inner.push(&JsValue::from_f64(idx as f64));
-        outer.push(&inner);
-    }
-    outer
+pub fn chart_trends_peaks(
+    prices: Vec<f64>,
+    period: usize,
+    closest_neighbor: usize,
+) -> Result<Array, JsValue> {
+    let pairs =
+        centaur_technical_indicators::chart_trends::peaks(&prices, period, closest_neighbor)
+            .map_err(js_err)?;
+    Ok(pairs_to_array(pairs.into_iter().map(|(v, i)| (v, i as f64))))
 }
 
 // valleys: Vec<(f64, usize)> -> Array<[value, index]>
 #[wasm_bindgen(js_name = chart_trends_valleys)]
-pub fn chart_trends_valleys(prices: Vec<f64>, period: usize, closest_neighbor: usize) -> Array {
-    let pairs = centaur_technical_indicators::chart_trends::valleys(&prices, period, closest_neighbor)
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (val, idx) in pairs {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(val));
-        inner.push(&JsValue::from_f64(idx as f64));
-        outer.push(&inner);
-    }
-    outer
+pub fn chart_trends_valleys(
+    prices: Vec<f64>,
+    period: usize,
+    closest_neighbor: usize,
+) -> Result<Array, JsValue> {
+    let pairs =
+        centaur_technical_indicators::chart_trends::valleys(&prices, period, closest_neighbor)
+            .map_err(js_err)?;
+    Ok(pairs_to_array(pairs.into_iter().map(|(v, i)| (v, i as f64))))
 }
 
 // peak_trend: (f64, f64) -> [slope, intercept]
 #[wasm_bindgen(js_name = chart_trends_peakTrend)]
-pub fn chart_trends_peak_trend(prices: Vec<f64>, period: usize) -> Array {
-    let (slope, intercept) = centaur_technical_indicators::chart_trends::peak_trend(&prices, period)
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(slope));
-    arr.push(&JsValue::from_f64(intercept));
-    arr
+pub fn chart_trends_peak_trend(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let pair = centaur_technical_indicators::chart_trends::peak_trend(&prices, period)
+        .map_err(js_err)?;
+    Ok(pair_to_array(pair))
 }
 
 // valley_trend: (f64, f64) -> [slope, intercept]
 #[wasm_bindgen(js_name = chart_trends_valleyTrend)]
-pub fn chart_trends_valley_trend(prices: Vec<f64>, period: usize) -> Array {
-    let (slope, intercept) = centaur_technical_indicators::chart_trends::valley_trend(&prices, period)
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(slope));
-    arr.push(&JsValue::from_f64(intercept));
-    arr
+pub fn chart_trends_valley_trend(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let pair = centaur_technical_indicators::chart_trends::valley_trend(&prices, period)
+        .map_err(js_err)?;
+    Ok(pair_to_array(pair))
 }
 
 // overall_trend: (f64, f64) -> [slope, intercept]
 #[wasm_bindgen(js_name = chart_trends_overallTrend)]
-pub fn chart_trends_overall_trend(prices: Vec<f64>) -> Array {
-    let (slope, intercept) = centaur_technical_indicators::chart_trends::overall_trend(&prices)
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(slope));
-    arr.push(&JsValue::from_f64(intercept));
-    arr
+pub fn chart_trends_overall_trend(prices: Vec<f64>) -> Result<Array, JsValue> {
+    let pair =
+        centaur_technical_indicators::chart_trends::overall_trend(&prices).map_err(js_err)?;
+    Ok(pair_to_array(pair))
 }
 
 // break_down_trends: Vec<(usize, usize, f64, f64)> -> Array<[start, end, slope, intercept]>
-// Updated to use TrendBreakConfig in centaur_technical_indicators 1.0.0
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen(js_name = chart_trends_breakDownTrends)]
 pub fn chart_trends_break_down_trends(
@@ -82,7 +69,7 @@ pub fn chart_trends_break_down_trends(
     soft_durbin_watson_max: f64,
     hard_durbin_watson_min: f64,
     hard_durbin_watson_max: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let config = centaur_technical_indicators::chart_trends::TrendBreakConfig {
         max_outliers,
         soft_adj_r_squared_minimum,
@@ -96,15 +83,8 @@ pub fn chart_trends_break_down_trends(
     };
 
     let segments = centaur_technical_indicators::chart_trends::break_down_trends(&prices, config)
-        .expect("Failed to calculate indicator");
-    let outer = Array::new();
-    for (start, end, slope, intercept) in segments {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(start as f64));
-        inner.push(&JsValue::from_f64(end as f64));
-        inner.push(&JsValue::from_f64(slope));
-        inner.push(&JsValue::from_f64(intercept));
-        outer.push(&inner);
-    }
-    outer
+        .map_err(js_err)?;
+    Ok(quads_to_array(segments.into_iter().map(
+        |(start, end, slope, intercept)| (start as f64, end as f64, slope, intercept),
+    )))
 }

--- a/src/correlation_indicators.rs
+++ b/src/correlation_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -9,14 +10,14 @@ pub fn correlation_single_correlate_asset_prices(
     prices_asset_b: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::correlation_indicators::single::correlate_asset_prices(
         &prices_asset_a,
         &prices_asset_b,
         constant_model_type.into(),
         deviation_model.into(),
     )
-    .expect("Failed to correlate asset prices")
+    .map_err(js_err)
 }
 
 /// Rolling correlation over a period: returns Array<number>
@@ -27,7 +28,7 @@ pub fn correlation_bulk_correlate_asset_prices(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::correlation_indicators::bulk::correlate_asset_prices(
         &prices_asset_a,
         &prices_asset_b,
@@ -35,10 +36,6 @@ pub fn correlation_bulk_correlate_asset_prices(
         deviation_model.into(),
         period,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/jsutil.rs
+++ b/src/jsutil.rs
@@ -1,0 +1,82 @@
+use js_sys::Array;
+use wasm_bindgen::JsValue;
+
+/// Convert any Rust error type that implements `Display` (typically
+/// `TechnicalIndicatorError`) into a `JsValue` carrying a native JS `Error`.
+/// The error's `Display` message is preserved so JS consumers see e.g.
+/// "Mismatched lengths: highs=5, lows=4" instead of a panic string.
+pub(crate) fn js_err(e: impl std::fmt::Display) -> JsValue {
+    JsValue::from(js_sys::Error::new(&e.to_string()))
+}
+
+pub(crate) fn flat_to_array<I: IntoIterator<Item = f64>>(data: I) -> Array {
+    let out = Array::new();
+    for v in data {
+        out.push(&JsValue::from_f64(v));
+    }
+    out
+}
+
+pub(crate) fn pair_to_array((a, b): (f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr
+}
+
+pub(crate) fn triple_to_array((a, b, c): (f64, f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr.push(&JsValue::from_f64(c));
+    arr
+}
+
+pub(crate) fn quintuple_to_array((a, b, c, d, e): (f64, f64, f64, f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr.push(&JsValue::from_f64(c));
+    arr.push(&JsValue::from_f64(d));
+    arr.push(&JsValue::from_f64(e));
+    arr
+}
+
+pub(crate) fn pairs_to_array<I: IntoIterator<Item = (f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for p in data {
+        outer.push(&pair_to_array(p));
+    }
+    outer
+}
+
+pub(crate) fn triples_to_array<I: IntoIterator<Item = (f64, f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for t in data {
+        outer.push(&triple_to_array(t));
+    }
+    outer
+}
+
+pub(crate) fn quads_to_array<I: IntoIterator<Item = (f64, f64, f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for (a, b, c, d) in data {
+        let inner = Array::new();
+        inner.push(&JsValue::from_f64(a));
+        inner.push(&JsValue::from_f64(b));
+        inner.push(&JsValue::from_f64(c));
+        inner.push(&JsValue::from_f64(d));
+        outer.push(&inner);
+    }
+    outer
+}
+
+pub(crate) fn quintuples_to_array<I: IntoIterator<Item = (f64, f64, f64, f64, f64)>>(
+    data: I,
+) -> Array {
+    let outer = Array::new();
+    for q in data {
+        outer.push(&quintuple_to_array(q));
+    }
+    outer
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,10 @@ impl From<Position> for centaur_technical_indicators::Position {
     }
 }
 
+// Internal helper module — array converters and structured-error adapter.
+// Not exposed via wasm_bindgen; consumed by the binding modules only.
+pub(crate) mod jsutil;
+
 // Mirror Centaur Technical Indicators structure
 pub mod candle_indicators;
 pub mod chart_trends;

--- a/src/momentum_indicators.rs
+++ b/src/momentum_indicators.rs
@@ -1,3 +1,6 @@
+use crate::jsutil::{
+    flat_to_array, js_err, pair_to_array, pairs_to_array, triple_to_array, triples_to_array,
+};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -7,18 +10,18 @@ use wasm_bindgen::JsValue;
 pub fn momentum_single_relative_strength_index(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::relative_strength_index(
         &prices,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate RSI")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_stochasticOscillator)]
-pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> f64 {
+pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::stochastic_oscillator(&prices)
-        .expect("Failed to calculate stochastic oscillator")
+        .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -26,9 +29,12 @@ pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> f64 {
 pub fn momentum_single_slow_stochastic(
     stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
-    centaur_technical_indicators::momentum_indicators::single::slow_stochastic(&stochastics, constant_model_type.into())
-        .expect("Failed to calculate slow stochastic")
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::momentum_indicators::single::slow_stochastic(
+        &stochastics,
+        constant_model_type.into(),
+    )
+    .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -36,30 +42,45 @@ pub fn momentum_single_slow_stochastic(
 pub fn momentum_single_slowest_stochastic(
     slow_stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::slowest_stochastic(
         &slow_stochastics,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate slowest stochastic")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_williamsPercentR)]
-pub fn momentum_single_williams_percent_r(high: Vec<f64>, low: Vec<f64>, close: f64) -> f64 {
-    centaur_technical_indicators::momentum_indicators::single::williams_percent_r(&high, &low, close)
-        .expect("Failed to calculate Williams %R")
+pub fn momentum_single_williams_percent_r(
+    high: Vec<f64>,
+    low: Vec<f64>,
+    close: f64,
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::momentum_indicators::single::williams_percent_r(
+        &high, &low, close,
+    )
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_moneyFlowIndex)]
-pub fn momentum_single_money_flow_index(prices: Vec<f64>, volume: Vec<f64>) -> f64 {
+pub fn momentum_single_money_flow_index(
+    prices: Vec<f64>,
+    volume: Vec<f64>,
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::money_flow_index(&prices, &volume)
-        .expect("Failed to calculate Money Flow Index")
+        .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_rateOfChange)]
-pub fn momentum_single_rate_of_change(current_price: f64, previous_price: f64) -> f64 {
-    centaur_technical_indicators::momentum_indicators::single::rate_of_change(current_price, previous_price)
-        .expect("Failed to calculate rate of change")
+pub fn momentum_single_rate_of_change(
+    current_price: f64,
+    previous_price: f64,
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::momentum_indicators::single::rate_of_change(
+        current_price,
+        previous_price,
+    )
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_onBalanceVolume)]
@@ -68,14 +89,14 @@ pub fn momentum_single_on_balance_volume(
     previous_price: f64,
     current_volume: f64,
     previous_on_balance_volume: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::on_balance_volume(
         current_price,
         previous_price,
         current_volume,
         previous_on_balance_volume,
     )
-    .expect("Failed to calculate On Balance Volume")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_commodityChannelIndex)]
@@ -84,14 +105,14 @@ pub fn momentum_single_commodity_channel_index(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::commodity_channel_index(
         &prices,
         constant_model_type.into(),
         deviation_model.into(),
         constant_multiplier,
     )
-    .expect("Failed to calculate Commodity Channel Index")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_mcginleyDynamicCommodityChannelIndex)]
@@ -100,18 +121,16 @@ pub fn momentum_single_mcginley_dynamic_commodity_channel_index(
     previous_mcginley_dynamic: f64,
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
-) -> Array {
-    let (v, m) = centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_commodity_channel_index(
-        &prices,
-        previous_mcginley_dynamic,
-        deviation_model.into(),
-        constant_multiplier,
-    )
-    .expect("Failed to calculate McGinley Dynamic CCI");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(v));
-    arr.push(&JsValue::from_f64(m));
-    arr
+) -> Result<Array, JsValue> {
+    let pair =
+        centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_commodity_channel_index(
+            &prices,
+            previous_mcginley_dynamic,
+            deviation_model.into(),
+            constant_multiplier,
+        )
+        .map_err(js_err)?;
+    Ok(pair_to_array(pair))
 }
 
 #[wasm_bindgen(js_name = momentum_single_macdLine)]
@@ -120,14 +139,14 @@ pub fn momentum_single_macd_line(
     short_period: usize,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::macd_line(
         &prices,
         short_period,
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate MACD line")
+    .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -135,9 +154,12 @@ pub fn momentum_single_macd_line(
 pub fn momentum_single_signal_line(
     macds: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
-    centaur_technical_indicators::momentum_indicators::single::signal_line(&macds, constant_model_type.into())
-        .expect("Failed to calculate signal line")
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::momentum_indicators::single::signal_line(
+        &macds,
+        constant_model_type.into(),
+    )
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_mcginleyDynamicMacdLine)]
@@ -146,19 +168,15 @@ pub fn momentum_single_mcginley_dynamic_macd_line(
     short_period: usize,
     previous_short_mcginley: f64,
     previous_long_mcginley: f64,
-) -> Array {
-    let (macd, short_m, long_m) = centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_macd_line(
+) -> Result<Array, JsValue> {
+    let triple = centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_macd_line(
         &prices,
         short_period,
         previous_short_mcginley,
         previous_long_mcginley,
     )
-    .expect("Failed to calculate McGinley Dynamic MACD line");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(macd));
-    arr.push(&JsValue::from_f64(short_m));
-    arr.push(&JsValue::from_f64(long_m));
-    arr
+    .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = momentum_single_chaikinOscillator)]
@@ -171,8 +189,8 @@ pub fn momentum_single_chaikin_oscillator(
     previous_accumulation_distribution: f64,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> Array {
-    let (v, ad) = centaur_technical_indicators::momentum_indicators::single::chaikin_oscillator(
+) -> Result<Array, JsValue> {
+    let pair = centaur_technical_indicators::momentum_indicators::single::chaikin_oscillator(
         &highs,
         &lows,
         &close,
@@ -182,11 +200,8 @@ pub fn momentum_single_chaikin_oscillator(
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate Chaikin Oscillator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(v));
-    arr.push(&JsValue::from_f64(ad));
-    arr
+    .map_err(js_err)?;
+    Ok(pair_to_array(pair))
 }
 
 #[wasm_bindgen(js_name = momentum_single_percentagePriceOscillator)]
@@ -194,19 +209,19 @@ pub fn momentum_single_percentage_price_oscillator(
     prices: Vec<f64>,
     short_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::percentage_price_oscillator(
         &prices,
         short_period,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate Percentage Price Oscillator")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_chandeMomentumOscillator)]
-pub fn momentum_single_chande_momentum_oscillator(prices: Vec<f64>) -> f64 {
+pub fn momentum_single_chande_momentum_oscillator(prices: Vec<f64>) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::chande_momentum_oscillator(&prices)
-        .expect("Failed to calculate Chande Momentum Oscillator")
+        .map_err(js_err)
 }
 
 // -------- BULK --------
@@ -215,29 +230,26 @@ pub fn momentum_bulk_relative_strength_index(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::relative_strength_index(
         &prices,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate RSI values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_stochasticOscillator)]
-pub fn momentum_bulk_stochastic_oscillator(prices: Vec<f64>, period: usize) -> Array {
-    let data = centaur_technical_indicators::momentum_indicators::bulk::stochastic_oscillator(&prices, period)
-        .expect("Failed to calculate stochastic oscillator values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn momentum_bulk_stochastic_oscillator(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::momentum_indicators::bulk::stochastic_oscillator(
+        &prices, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[allow(deprecated)]
@@ -246,18 +258,14 @@ pub fn momentum_bulk_slow_stochastic(
     stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::slow_stochastic(
         &stochastics,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate slow stochastic values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[allow(deprecated)]
@@ -266,18 +274,14 @@ pub fn momentum_bulk_slowest_stochastic(
     slow_stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::slowest_stochastic(
         &slow_stochastics,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate slowest stochastic values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_williamsPercentR)]
@@ -286,36 +290,32 @@ pub fn momentum_bulk_williams_percent_r(
     low: Vec<f64>,
     close: Vec<f64>,
     period: usize,
-) -> Array {
-    let data = centaur_technical_indicators::momentum_indicators::bulk::williams_percent_r(&high, &low, &close, period)
-        .expect("Failed to calculate Williams %R values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::momentum_indicators::bulk::williams_percent_r(
+        &high, &low, &close, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_moneyFlowIndex)]
-pub fn momentum_bulk_money_flow_index(prices: Vec<f64>, volume: Vec<f64>, period: usize) -> Array {
-    let data = centaur_technical_indicators::momentum_indicators::bulk::money_flow_index(&prices, &volume, period)
-        .expect("Failed to calculate Money Flow Index values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn momentum_bulk_money_flow_index(
+    prices: Vec<f64>,
+    volume: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::momentum_indicators::bulk::money_flow_index(
+        &prices, &volume, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_rateOfChange)]
-pub fn momentum_bulk_rate_of_change(prices: Vec<f64>) -> Array {
+pub fn momentum_bulk_rate_of_change(prices: Vec<f64>) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::rate_of_change(&prices)
-        .expect("Failed to calculate rate of change values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_onBalanceVolume)]
@@ -323,18 +323,14 @@ pub fn momentum_bulk_on_balance_volume(
     prices: Vec<f64>,
     volume: Vec<f64>,
     previous_on_balance_volume: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::on_balance_volume(
         &prices,
         &volume,
         previous_on_balance_volume,
     )
-    .expect("Failed to calculate On Balance Volume values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_commodityChannelIndex)]
@@ -344,7 +340,7 @@ pub fn momentum_bulk_commodity_channel_index(
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::commodity_channel_index(
         &prices,
         constant_model_type.into(),
@@ -352,12 +348,8 @@ pub fn momentum_bulk_commodity_channel_index(
         constant_multiplier,
         period,
     )
-    .expect("Failed to calculate CCI values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_mcginleyDynamicCommodityChannelIndex)]
@@ -367,23 +359,17 @@ pub fn momentum_bulk_mcginley_dynamic_commodity_channel_index(
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
     period: usize,
-) -> Array {
-    let data = centaur_technical_indicators::momentum_indicators::bulk::mcginley_dynamic_commodity_channel_index(
-        &prices,
-        previous_mcginley_dynamic,
-        deviation_model.into(),
-        constant_multiplier,
-        period,
-    )
-    .expect("Failed to calculate McGinley Dynamic CCI values");
-    let out = Array::new();
-    for (v, m) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(v));
-        inner.push(&JsValue::from_f64(m));
-        out.push(&inner);
-    }
-    out
+) -> Result<Array, JsValue> {
+    let data =
+        centaur_technical_indicators::momentum_indicators::bulk::mcginley_dynamic_commodity_channel_index(
+            &prices,
+            previous_mcginley_dynamic,
+            deviation_model.into(),
+            constant_multiplier,
+            period,
+        )
+        .map_err(js_err)?;
+    Ok(pairs_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_macdLine)]
@@ -393,7 +379,7 @@ pub fn momentum_bulk_macd_line(
     short_period_model: crate::ConstantModelType,
     long_period: usize,
     long_period_model: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::macd_line(
         &prices,
         short_period,
@@ -401,12 +387,8 @@ pub fn momentum_bulk_macd_line(
         long_period,
         long_period_model.into(),
     )
-    .expect("Failed to calculate MACD line values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[allow(deprecated)]
@@ -415,15 +397,14 @@ pub fn momentum_bulk_signal_line(
     macds: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
-    let data =
-        centaur_technical_indicators::momentum_indicators::bulk::signal_line(&macds, constant_model_type.into(), period)
-            .expect("Failed to calculate signal line values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::momentum_indicators::bulk::signal_line(
+        &macds,
+        constant_model_type.into(),
+        period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_mcginleyDynamicMacdLine)]
@@ -433,7 +414,7 @@ pub fn momentum_bulk_mcginley_dynamic_macd_line(
     previous_short_mcginley: f64,
     long_period: usize,
     previous_long_mcginley: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::mcginley_dynamic_macd_line(
         &prices,
         short_period,
@@ -441,16 +422,8 @@ pub fn momentum_bulk_mcginley_dynamic_macd_line(
         long_period,
         previous_long_mcginley,
     )
-    .expect("Failed to calculate McGinley Dynamic MACD line values");
-    let out = Array::new();
-    for (macd, short_m, long_m) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(macd));
-        inner.push(&JsValue::from_f64(short_m));
-        inner.push(&JsValue::from_f64(long_m));
-        out.push(&inner);
-    }
-    out
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_chaikinOscillator)]
@@ -464,7 +437,7 @@ pub fn momentum_bulk_chaikin_oscillator(
     previous_accumulation_distribution: f64,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::chaikin_oscillator(
         &highs,
         &lows,
@@ -476,15 +449,8 @@ pub fn momentum_bulk_chaikin_oscillator(
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate Chaikin Oscillator values");
-    let out = Array::new();
-    for (v, ad) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(v));
-        inner.push(&JsValue::from_f64(ad));
-        out.push(&inner);
-    }
-    out
+    .map_err(js_err)?;
+    Ok(pairs_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_percentagePriceOscillator)]
@@ -493,28 +459,25 @@ pub fn momentum_bulk_percentage_price_oscillator(
     short_period: usize,
     long_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::percentage_price_oscillator(
         &prices,
         short_period,
         long_period,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate Percentage Price Oscillator values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_chandeMomentumOscillator)]
-pub fn momentum_bulk_chande_momentum_oscillator(prices: Vec<f64>, period: usize) -> Array {
-    let data = centaur_technical_indicators::momentum_indicators::bulk::chande_momentum_oscillator(&prices, period)
-        .expect("Failed to calculate Chande Momentum Oscillator values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn momentum_bulk_chande_momentum_oscillator(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::momentum_indicators::bulk::chande_momentum_oscillator(
+        &prices, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/moving_average.rs
+++ b/src/moving_average.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -5,9 +6,12 @@ use wasm_bindgen::JsValue;
 // -------- SINGLE --------
 
 #[wasm_bindgen(js_name = ma_single_movingAverage)]
-pub fn ma_single_moving_average(prices: Vec<f64>, ma_type: crate::MovingAverageType) -> f64 {
+pub fn ma_single_moving_average(
+    prices: Vec<f64>,
+    ma_type: crate::MovingAverageType,
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::moving_average::single::moving_average(&prices, ma_type.into())
-        .expect("Failed to calculate moving average")
+        .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = ma_single_mcginleyDynamic)]
@@ -15,13 +19,13 @@ pub fn ma_single_mcginley_dynamic(
     latest_price: f64,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::moving_average::single::mcginley_dynamic(
         latest_price,
         previous_mcginley_dynamic,
         period,
     )
-    .expect("Failed to calculate McGinley Dynamic")
+    .map_err(js_err)
 }
 
 // -------- BULK --------
@@ -31,14 +35,14 @@ pub fn ma_bulk_moving_average(
     prices: Vec<f64>,
     ma_type: crate::MovingAverageType,
     period: usize,
-) -> Array {
-    let data = centaur_technical_indicators::moving_average::bulk::moving_average(&prices, ma_type.into(), period)
-        .expect("Failed to calculate moving averages");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::moving_average::bulk::moving_average(
+        &prices,
+        ma_type.into(),
+        period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = ma_bulk_mcginleyDynamic)]
@@ -46,13 +50,12 @@ pub fn ma_bulk_mcginley_dynamic(
     prices: Vec<f64>,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> Array {
-    let data =
-        centaur_technical_indicators::moving_average::bulk::mcginley_dynamic(&prices, previous_mcginley_dynamic, period)
-            .expect("Failed to calculate McGinley Dynamic values");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::moving_average::bulk::mcginley_dynamic(
+        &prices,
+        previous_mcginley_dynamic,
+        period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/other_indicators.rs
+++ b/src/other_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err, pair_to_array, pairs_to_array};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -11,12 +12,13 @@ pub fn other_single_return_on_investment(
     end_price: f64,
     investment: f64,
 ) -> Array {
-    let (final_value, percent_return) =
-        centaur_technical_indicators::other_indicators::single::return_on_investment(start_price, end_price, investment);
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(final_value));
-    arr.push(&JsValue::from_f64(percent_return));
-    arr
+    pair_to_array(
+        centaur_technical_indicators::other_indicators::single::return_on_investment(
+            start_price,
+            end_price,
+            investment,
+        ),
+    )
 }
 
 /// true_range -> number
@@ -32,14 +34,14 @@ pub fn other_single_average_true_range(
     high: Vec<f64>,
     low: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::other_indicators::single::average_true_range(
         &close,
         &high,
         &low,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate average true range")
+    .map_err(js_err)
 }
 
 /// internal_bar_strength -> number
@@ -52,29 +54,21 @@ pub fn other_single_internal_bar_strength(high: f64, low: f64, close: f64) -> f6
 
 /// return_on_investment -> Array<[final_value, percent_return]>
 #[wasm_bindgen(js_name = other_bulk_returnOnInvestment)]
-pub fn other_bulk_return_on_investment(prices: Vec<f64>, investment: f64) -> Array {
-    let data = centaur_technical_indicators::other_indicators::bulk::return_on_investment(&prices, investment)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for (final_value, percent_return) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(final_value));
-        inner.push(&JsValue::from_f64(percent_return));
-        out.push(&inner);
-    }
-    out
+pub fn other_bulk_return_on_investment(prices: Vec<f64>, investment: f64) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::other_indicators::bulk::return_on_investment(
+        &prices, investment,
+    )
+    .map_err(js_err)?;
+    Ok(pairs_to_array(data))
 }
 
 /// true_range -> Array<number>
 #[wasm_bindgen(js_name = other_bulk_trueRange)]
-pub fn other_bulk_true_range(close: Vec<f64>, high: Vec<f64>, low: Vec<f64>) -> Array {
-    let data = centaur_technical_indicators::other_indicators::bulk::true_range(&close, &high, &low)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn other_bulk_true_range(close: Vec<f64>, high: Vec<f64>, low: Vec<f64>) -> Result<Array, JsValue> {
+    let data =
+        centaur_technical_indicators::other_indicators::bulk::true_range(&close, &high, &low)
+            .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 /// average_true_range -> Array<number>
@@ -85,7 +79,7 @@ pub fn other_bulk_average_true_range(
     low: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::average_true_range(
         &close,
         &high,
@@ -93,24 +87,22 @@ pub fn other_bulk_average_true_range(
         constant_model_type.into(),
         period,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 /// internal_bar_strength -> Array<number>
 #[wasm_bindgen(js_name = other_bulk_internalBarStrength)]
-pub fn other_bulk_internal_bar_strength(high: Vec<f64>, low: Vec<f64>, close: Vec<f64>) -> Array {
-    let data = centaur_technical_indicators::other_indicators::bulk::internal_bar_strength(&high, &low, &close)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn other_bulk_internal_bar_strength(
+    high: Vec<f64>,
+    low: Vec<f64>,
+    close: Vec<f64>,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::other_indicators::bulk::internal_bar_strength(
+        &high, &low, &close,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 /// positivity_indicator -> Array<[pi, signal]>
@@ -120,20 +112,13 @@ pub fn other_bulk_positivity_indicator(
     previous_close: Vec<f64>,
     signal_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::positivity_indicator(
         &open,
         &previous_close,
         signal_period,
         constant_model_type.into(),
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for (pi, sig) in data {
-        let inner = Array::new();
-        inner.push(&JsValue::from_f64(pi));
-        inner.push(&JsValue::from_f64(sig));
-        out.push(&inner);
-    }
-    out
+    .map_err(js_err)?;
+    Ok(pairs_to_array(data))
 }

--- a/src/strength_indicators.rs
+++ b/src/strength_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -41,7 +42,7 @@ pub fn strength_single_relative_vigor_index(
     low: Vec<f64>,
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::strength_indicators::single::relative_vigor_index(
         &open,
         &high,
@@ -49,7 +50,7 @@ pub fn strength_single_relative_vigor_index(
         &close,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate relative vigor index")
+    .map_err(js_err)
 }
 
 // -------- BULK --------
@@ -61,7 +62,7 @@ pub fn strength_bulk_accumulation_distribution(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_accumulation_distribution: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::accumulation_distribution(
         &high,
         &low,
@@ -69,12 +70,8 @@ pub fn strength_bulk_accumulation_distribution(
         &volume,
         previous_accumulation_distribution,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = strength_bulk_positiveVolumeIndex)]
@@ -82,18 +79,14 @@ pub fn strength_bulk_positive_volume_index(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_positive_volume_index: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::positive_volume_index(
         &close,
         &volume,
         previous_positive_volume_index,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = strength_bulk_negativeVolumeIndex)]
@@ -101,18 +94,14 @@ pub fn strength_bulk_negative_volume_index(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_negative_volume_index: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::negative_volume_index(
         &close,
         &volume,
         previous_negative_volume_index,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = strength_bulk_relativeVigorIndex)]
@@ -123,7 +112,7 @@ pub fn strength_bulk_relative_vigor_index(
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::relative_vigor_index(
         &open,
         &high,
@@ -132,10 +121,6 @@ pub fn strength_bulk_relative_vigor_index(
         constant_model_type.into(),
         period,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/trend_indicators.rs
+++ b/src/trend_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err, quads_to_array, triple_to_array, triples_to_array};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -5,15 +6,13 @@ use wasm_bindgen::JsValue;
 // -------- SINGLE --------
 
 #[wasm_bindgen(js_name = trend_single_aroonUp)]
-pub fn trend_single_aroon_up(highs: Vec<f64>) -> f64 {
-    centaur_technical_indicators::trend_indicators::single::aroon_up(&highs)
-        .expect("Failed to calculate Aroon Up")
+pub fn trend_single_aroon_up(highs: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::trend_indicators::single::aroon_up(&highs).map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = trend_single_aroonDown)]
-pub fn trend_single_aroon_down(lows: Vec<f64>) -> f64 {
-    centaur_technical_indicators::trend_indicators::single::aroon_down(&lows)
-        .expect("Failed to calculate Aroon Down")
+pub fn trend_single_aroon_down(lows: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::trend_indicators::single::aroon_down(&lows).map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = trend_single_aroonOscillator)]
@@ -22,14 +21,11 @@ pub fn trend_single_aroon_oscillator(aroon_up: f64, aroon_down: f64) -> f64 {
 }
 
 #[wasm_bindgen(js_name = trend_single_aroonIndicator)]
-pub fn trend_single_aroon_indicator(highs: Vec<f64>, lows: Vec<f64>) -> Array {
-    let (up, down, osc) = centaur_technical_indicators::trend_indicators::single::aroon_indicator(&highs, &lows)
-        .expect("Failed to calculate indicator");
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(up));
-    arr.push(&JsValue::from_f64(down));
-    arr.push(&JsValue::from_f64(osc));
-    arr
+pub fn trend_single_aroon_indicator(highs: Vec<f64>, lows: Vec<f64>) -> Result<Array, JsValue> {
+    let triple =
+        centaur_technical_indicators::trend_indicators::single::aroon_indicator(&highs, &lows)
+            .map_err(js_err)?;
+    Ok(triple_to_array(triple))
 }
 
 #[wasm_bindgen(js_name = trend_single_longParabolicTimePriceSystem)]
@@ -83,64 +79,55 @@ pub fn trend_single_true_strength_index(
     first_constant_model: crate::ConstantModelType,
     first_period: usize,
     second_constant_model: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::trend_indicators::single::true_strength_index(
         &prices,
         first_constant_model.into(),
         first_period,
         second_constant_model.into(),
     )
-    .expect("Failed to calculate True Strength Index")
+    .map_err(js_err)
 }
 
 // -------- BULK --------
 
 #[wasm_bindgen(js_name = trend_bulk_aroonUp)]
-pub fn trend_bulk_aroon_up(highs: Vec<f64>, period: usize) -> Array {
+pub fn trend_bulk_aroon_up(highs: Vec<f64>, period: usize) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::trend_indicators::bulk::aroon_up(&highs, period)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_aroonDown)]
-pub fn trend_bulk_aroon_down(lows: Vec<f64>, period: usize) -> Array {
+pub fn trend_bulk_aroon_down(lows: Vec<f64>, period: usize) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::trend_indicators::bulk::aroon_down(&lows, period)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_aroonOscillator)]
-pub fn trend_bulk_aroon_oscillator(aroon_up: Vec<f64>, aroon_down: Vec<f64>) -> Array {
-    let data = centaur_technical_indicators::trend_indicators::bulk::aroon_oscillator(&aroon_up, &aroon_down)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+pub fn trend_bulk_aroon_oscillator(
+    aroon_up: Vec<f64>,
+    aroon_down: Vec<f64>,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::trend_indicators::bulk::aroon_oscillator(
+        &aroon_up, &aroon_down,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_aroonIndicator)]
-pub fn trend_bulk_aroon_indicator(highs: Vec<f64>, lows: Vec<f64>, period: usize) -> Array {
-    let data = centaur_technical_indicators::trend_indicators::bulk::aroon_indicator(&highs, &lows, period)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for (up, down, osc) in data {
-        let t = Array::new();
-        t.push(&JsValue::from_f64(up));
-        t.push(&JsValue::from_f64(down));
-        t.push(&JsValue::from_f64(osc));
-        out.push(&t);
-    }
-    out
+pub fn trend_bulk_aroon_indicator(
+    highs: Vec<f64>,
+    lows: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::trend_indicators::bulk::aroon_indicator(
+        &highs, &lows, period,
+    )
+    .map_err(js_err)?;
+    Ok(triples_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_parabolicTimePriceSystem)]
@@ -152,7 +139,7 @@ pub fn trend_bulk_parabolic_time_price_system(
     acceleration_factor_step: f64,
     start_position: crate::Position,
     previous_sar: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::trend_indicators::bulk::parabolic_time_price_system(
         &highs,
         &lows,
@@ -162,12 +149,8 @@ pub fn trend_bulk_parabolic_time_price_system(
         start_position.into(),
         previous_sar,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_directionalMovementSystem)]
@@ -177,7 +160,7 @@ pub fn trend_bulk_directional_movement_system(
     close: Vec<f64>,
     period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::trend_indicators::bulk::directional_movement_system(
         &highs,
         &lows,
@@ -185,17 +168,8 @@ pub fn trend_bulk_directional_movement_system(
         period,
         constant_model_type.into(),
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for (pdi, ndi, adx, adxr) in data {
-        let t = Array::new();
-        t.push(&JsValue::from_f64(pdi));
-        t.push(&JsValue::from_f64(ndi));
-        t.push(&JsValue::from_f64(adx));
-        t.push(&JsValue::from_f64(adxr));
-        out.push(&t);
-    }
-    out
+    .map_err(js_err)?;
+    Ok(quads_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_volumePriceTrend)]
@@ -203,25 +177,21 @@ pub fn trend_bulk_volume_price_trend(
     prices: Vec<f64>,
     volumes: Vec<f64>,
     previous_volume_price_trend: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     // Handle both same-length arrays (skip first volume) and L-1 length arrays (backward compat)
     let volumes_slice = if volumes.len() == prices.len() {
         &volumes[1..]
     } else {
         &volumes
     };
-    
+
     let data = centaur_technical_indicators::trend_indicators::bulk::volume_price_trend(
         &prices,
         volumes_slice,
         previous_volume_price_trend,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[wasm_bindgen(js_name = trend_bulk_trueStrengthIndex)]
@@ -231,7 +201,7 @@ pub fn trend_bulk_true_strength_index(
     first_period: usize,
     second_constant_model: crate::ConstantModelType,
     second_period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::trend_indicators::bulk::true_strength_index(
         &prices,
         first_constant_model.into(),
@@ -239,10 +209,6 @@ pub fn trend_bulk_true_strength_index(
         second_constant_model.into(),
         second_period,
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }

--- a/src/volatility_indicators.rs
+++ b/src/volatility_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::{flat_to_array, js_err};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -5,22 +6,18 @@ use wasm_bindgen::JsValue;
 // -------- SINGLE --------
 
 #[wasm_bindgen(js_name = volatility_single_ulcerIndex)]
-pub fn volatility_single_ulcer_index(prices: Vec<f64>) -> f64 {
+pub fn volatility_single_ulcer_index(prices: Vec<f64>) -> Result<f64, JsValue> {
     centaur_technical_indicators::volatility_indicators::single::ulcer_index(&prices)
-        .expect("Failed to calculate Ulcer Index")
+        .map_err(js_err)
 }
 
 // -------- BULK --------
 
 #[wasm_bindgen(js_name = volatility_bulk_ulcerIndex)]
-pub fn volatility_bulk_ulcer_index(prices: Vec<f64>, period: usize) -> Array {
+pub fn volatility_bulk_ulcer_index(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::volatility_indicators::bulk::ulcer_index(&prices, period)
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }
 
 #[allow(deprecated)]
@@ -32,7 +29,7 @@ pub fn volatility_bulk_volatility_system(
     period: usize,
     constant_multiplier: f64,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::volatility_indicators::bulk::volatility_system(
         &high,
         &low,
@@ -41,10 +38,6 @@ pub fn volatility_bulk_volatility_system(
         constant_multiplier,
         constant_model_type.into(),
     )
-        .expect("Failed to calculate indicator");
-    let out = Array::new();
-    for v in data {
-        out.push(&JsValue::from_f64(v));
-    }
-    out
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
 }


### PR DESCRIPTION
## Summary

Phase 2 of the JS-bindings improvement roadmap. Lifts the binding code quality across every module without changing happy-path semantics.

- **2.1 Structured errors:** replaced 86 `.expect("Failed to calculate …")` calls with `Result<T, JsValue>` returning `js_sys::Error` whose message preserves the upstream `TechnicalIndicatorError::Display` text. JS still throws on failure; the thrown `Error.message` is now informative (e.g. `Mismatched lengths: highs=5, lows=4`) rather than a generic panic string.
- **2.2 Array helpers:** new internal `src/jsutil.rs` (82 lines) with `js_err`, `flat_to_array`, `pair_to_array`, `triple_to_array`, `quintuple_to_array`, `pairs_to_array`, `triples_to_array`, `quads_to_array`, `quintuples_to_array`. Replaces the boilerplate that was open-coded across every binding. Binding code drops from ~1788 lines to ~1586 (excluding the new helper).
- **2.3 `volumePriceTrend` JSDoc (docs-only per maintainer decision):** rewrote the `trendIndicators.bulk.volumePriceTrend` JSDoc as a loud `⚠️ Warning` block explaining the silent first-volume drop when `volumes.length === prices.length`. No runtime change.
- **2.4 `breakDownTrendsWithConfig` (additive dual-shape per maintainer decision):** new `TrendBreakConfig` interface in `index.d.ts`; new `chartTrends.breakDownTrendsWithConfig(prices, config)` in the three JS wrappers. The positional `breakDownTrends` is preserved unchanged and dispatches to the same wasm export; it is marked `@deprecated since 1.3.0`.
- **2.5 `wasm-opt` at publish time:** `publish.yml` now downloads pinned binaryen `version_119` and runs `wasm-opt -O3` on each `dist/{web,node,bundler}/*_bg.wasm` before `npm publish`. Local/everyday CI builds remain fast (`Cargo.toml` still has `wasm-opt = false`).

## Scope

Modified every binding file in `src/`, both `lib.rs` (registers `jsutil` module), all three JS wrappers, `index.d.ts`, `CHANGELOG.md`, and `publish.yml`. Added `src/jsutil.rs`.

Intentionally not changed:
- `Cargo.toml` `wasm-opt = false` stays. Only `publish.yml` re-optimises.
- The positional `breakDownTrends` is kept for backwards compatibility per maintainer decision.
- No test changes in this PR — Phase 4 uncomments the existing `assert.throws` blocks and adds error-path coverage that depends on these structured errors.

## Compatibility

- **Happy path unchanged.** Every binding returns the same numeric output for valid inputs.
- **Failure path: thrown Error message text is different.** Previously: panic strings like `"Failed to calculate RSI"`. Now: structured upstream messages from `TechnicalIndicatorError::Display`. JS callers that match on the message text need updating; callers that rely on `try/catch` semantics or `Error.message.length > 0` are unaffected.
- `breakDownTrends` positional API: identical signature, identical wasm export — no breakage.
- Bundle size: published WASM should drop ~20-40% once `wasm-opt -O3` runs.

## Validation

Please run locally and report:
- `cargo fmt --all -- --check`
- `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `npm run build`
- `npm test`
- `grep -n '\.expect(' src/*.rs` — should be empty.

After Phase 1 (#17) lands and CI is wired up, the lint + clippy + test gates run automatically on this PR.

## Changelog

`Changed`, `Added`, `Performance` blocks under `[Unreleased]`.

## Cross-repo

No impact on `CentaurTechnicalIndicators-Python` or the published `centaur_technical_indicators` crate. Depends on neither Phase 0 (#16) nor Phase 1 (#17) — but does touch `publish.yml` (small merge conflict with Phase 1's `publish.yml` rewrite). Suggested merge order: 0 → 1 → 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)