### PR TITLE
Phase 3: expose basic_indicators (29 fns) + NumericArray alias + variant gap docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **New `basicIndicators` namespace exposing all 29 functions from the upstream
+  `basic_indicators` module** (15 single + 14 bulk). Includes `mean`, `median`,
+  `mode`, `log`/`logDifference`, `variance`, `standardDeviation`,
+  `absoluteDeviation`, `logStandardDeviation`, `studentTAdjustedStd`,
+  `laplaceStdEquivalent`, `cauchyIqrScale`, `max`, `min`, `priceDistribution`,
+  `empiricalQuantileRangeFromDistribution`. Closes the longest-standing API
+  coverage gap in this binding.
+- **New `CentralPoint` and `DeviationAggregate` enum mirrors** in
+  `src/lib.rs`, exposed to JS via the same `wasm_bindgen` pattern as the
+  existing enums. Used by `basicIndicators.{single,bulk}.absoluteDeviation`.
+  The upstream `AbsDevConfig { center, aggregate }` struct cannot be
+  constructed from JS via `wasm-bindgen`, so it is flattened to two positional
+  enum parameters (consistent with the existing flattening of
+  `chart_trends_breakDownTrends`'s nine positional arguments).
+- **New `NumericArray = number[] | Float64Array` TypeScript alias** (Codex
+  C-3.4). Used throughout the new `BasicIndicators*` interfaces. `wasm-bindgen`
+  has always accepted both at runtime; this alias makes that explicit in
+  TypeScript so consumers can pass `Float64Array` without a cast. The existing
+  `*Indicators*` interfaces still use `number[]`; broadening them to
+  `NumericArray` is a small mechanical follow-up.
+- **Parity test file `test/basicIndicators.node.test.js`** covers all 29
+  functions plus four error-path assertions. Parity values for IQR are lifted
+  from the upstream Rust `#[test]` blocks; values for mean/variance/std are
+  computed by hand for `[1,2,3,4,5]`.
+
+### Changed
+- `index.d.ts`: `ConstantModelType` and `DeviationModel` JSDoc gain
+  `@remarks` blocks listing the upstream parameterized variants that are
+  intentionally NOT exposed (`PersonalisedMovingAverage`,
+  `CustomAbsoluteDeviation`, `StudentT`, `EmpiricalQuantileRange`). These
+  cannot cross the `wasm-bindgen` boundary; the `@remarks` document the gap
+  so JS consumers stop hunting for variants that don't exist.
+
 ---
 
 ## [1.2.2] - 2026-04-04

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,19 @@
-import { ConstantModelType, DeviationModel, Position, MovingAverageType } from "./dist/bundler/centaur-technical-indicators";
+import {
+  ConstantModelType,
+  DeviationModel,
+  Position,
+  MovingAverageType,
+  CentralPoint,
+  DeviationAggregate,
+} from "./dist/bundler/centaur-technical-indicators";
+
+/**
+ * Numeric input type accepted by every binding that takes a price/volume
+ * series. `wasm-bindgen` accepts both `number[]` and `Float64Array` for
+ * any `Vec<f64>` parameter — this alias makes that explicit in TypeScript
+ * so consumers can pass `Float64Array` without a cast.
+ */
+export type NumericArray = number[] | Float64Array;
 
 // Re-export enums from the generated wasm types so consumers get both types and JSDoc.
 /**
@@ -8,6 +23,11 @@ import { ConstantModelType, DeviationModel, Position, MovingAverageType } from "
  * - ExponentialMovingAverage: EMA
  * - SimpleMovingMedian: median
  * - SimpleMovingMode: mode
+ *
+ * @remarks
+ * The upstream Rust crate also defines `PersonalisedMovingAverage { alpha_num, alpha_den }`.
+ * That parameterized variant cannot be constructed from JS via `wasm-bindgen`, so it is
+ * intentionally absent from this enum. Use the Rust crate directly if you need it.
  */
 export { ConstantModelType } from "./dist/bundler/centaur-technical-indicators";
 
@@ -21,8 +41,31 @@ export { ConstantModelType } from "./dist/bundler/centaur-technical-indicators";
  * - LogStandardDeviation
  * - LaplaceStdEquivalent
  * - CauchyIQRScale
+ *
+ * @remarks
+ * The upstream Rust crate also defines `CustomAbsoluteDeviation { config }`,
+ * `StudentT { df }`, and `EmpiricalQuantileRange { low, high, precision }`.
+ * These parameterized variants cannot be constructed from JS via `wasm-bindgen`,
+ * so they are intentionally absent from this enum. Use the Rust crate directly
+ * if you need them.
  */
 export { DeviationModel } from "./dist/bundler/centaur-technical-indicators";
+
+/**
+ * Central point used by `basicIndicators.absoluteDeviation` and related.
+ * - Mean
+ * - Median
+ * - Mode
+ */
+export { CentralPoint } from "./dist/bundler/centaur-technical-indicators";
+
+/**
+ * How to aggregate a set of absolute deviations.
+ * - Mean
+ * - Median
+ * - Mode
+ */
+export { DeviationAggregate } from "./dist/bundler/centaur-technical-indicators";
 
 /**
  * Trade direction for Parabolic SAR systems.
@@ -1885,6 +1928,127 @@ export const trendIndicators: {
 export const volatilityIndicators: {
   single: VolatilityIndicatorsSingle;
   bulk: VolatilityIndicatorsBulk;
+};
+
+/**
+ * Basic statistical and arithmetic helpers operating on whole input arrays
+ * and returning a single scalar (or a small structure).
+ */
+export interface BasicIndicatorsSingle {
+  /** Arithmetic mean of `prices`. */
+  mean(prices: NumericArray): number;
+  /** Median of `prices`. */
+  median(prices: NumericArray): number;
+  /** Mode of `prices` (most common bucket). */
+  mode(prices: NumericArray): number;
+  /** Natural-log price difference: `ln(price_t) - ln(price_t_1)`. */
+  logDifference(priceT: number, priceT1: number): number;
+  /** Population variance of `prices`. */
+  variance(prices: NumericArray): number;
+  /** Population standard deviation of `prices`. */
+  standardDeviation(prices: NumericArray): number;
+  /**
+   * Configurable absolute deviation. The upstream Rust `AbsDevConfig { center,
+   * aggregate }` is flattened to two positional enum parameters here, since
+   * `wasm-bindgen` cannot construct the struct from JS.
+   */
+  absoluteDeviation(
+    prices: NumericArray,
+    center: CentralPoint,
+    aggregate: DeviationAggregate,
+  ): number;
+  /** Standard deviation of `ln(prices)`. */
+  logStandardDeviation(prices: NumericArray): number;
+  /** Student-t-adjusted standard deviation with `df` degrees of freedom. */
+  studentTAdjustedStd(prices: NumericArray, df: number): number;
+  /** Laplace-distribution std-equivalent (median-of-medianAbsDev style). */
+  laplaceStdEquivalent(prices: NumericArray): number;
+  /** Cauchy-distribution IQR-based scale estimator. */
+  cauchyIqrScale(prices: NumericArray): number;
+  /** Maximum element of `prices`. */
+  max(prices: NumericArray): number;
+  /** Minimum element of `prices`. */
+  min(prices: NumericArray): number;
+  /**
+   * Price distribution at the given `precision`. Returns `[bucketCenter, count]`
+   * pairs; the second value is the integer count cast to a `number`.
+   */
+  priceDistribution(prices: NumericArray, precision: number): [number, number][];
+  /**
+   * Empirical inter-quantile range over the full series.
+   * @param prices Series to analyse.
+   * @param precision Bucket precision passed to `priceDistribution`.
+   * @param low Lower quantile in (0, 1).
+   * @param high Upper quantile in (0, 1) with `low < high`.
+   */
+  empiricalQuantileRangeFromDistribution(
+    prices: NumericArray,
+    precision: number,
+    low: number,
+    high: number,
+  ): number;
+}
+
+/**
+ * Rolling versions of the basic helpers. Each takes a `period` and returns a
+ * series of length `prices.length - period + 1`.
+ */
+export interface BasicIndicatorsBulk {
+  /** Rolling arithmetic mean. */
+  mean(prices: NumericArray, period: number): number[];
+  /** Rolling median. */
+  median(prices: NumericArray, period: number): number[];
+  /** Rolling mode. */
+  mode(prices: NumericArray, period: number): number[];
+  /** Element-wise natural log of `prices`. */
+  log(prices: NumericArray): number[];
+  /** Element-wise log-difference (length `L - 1`). */
+  logDifference(prices: NumericArray): number[];
+  /** Rolling population variance. */
+  variance(prices: NumericArray, period: number): number[];
+  /** Rolling population standard deviation. */
+  standardDeviation(prices: NumericArray, period: number): number[];
+  /** Rolling configurable absolute deviation (see single variant for `AbsDevConfig` note). */
+  absoluteDeviation(
+    prices: NumericArray,
+    period: number,
+    center: CentralPoint,
+    aggregate: DeviationAggregate,
+  ): number[];
+  /**
+   * Rolling price distribution. Returns one nested distribution per window,
+   * each shaped like the single-version output (`[bucketCenter, count]` pairs).
+   */
+  priceDistribution(
+    prices: NumericArray,
+    period: number,
+    precision: number,
+  ): [number, number][][];
+  /** Rolling log-standard-deviation. */
+  logStandardDeviation(prices: NumericArray, period: number): number[];
+  /** Rolling Student-t-adjusted standard deviation. */
+  studentTAdjustedStd(
+    prices: NumericArray,
+    period: number,
+    df: number,
+  ): number[];
+  /** Rolling Laplace-distribution std-equivalent. */
+  laplaceStdEquivalent(prices: NumericArray, period: number): number[];
+  /** Rolling Cauchy IQR-based scale estimator. */
+  cauchyIqrScale(prices: NumericArray, period: number): number[];
+  /** Rolling empirical inter-quantile range. */
+  empiricalQuantileRangeFromDistribution(
+    prices: NumericArray,
+    period: number,
+    precision: number,
+    low: number,
+    high: number,
+  ): number[];
+}
+
+export const basicIndicators: {
+  single: BasicIndicatorsSingle;
+  bulk: BasicIndicatorsBulk;
 };
 
 export const movingAverage: {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,55 @@
 import init, * as wasm from "./dist/bundler/centaur-technical-indicators.js";
 
 // Re-export enums
-export const { ConstantModelType, DeviationModel, Position, MovingAverageType } = wasm;
+export const {
+  ConstantModelType,
+  DeviationModel,
+  Position,
+  MovingAverageType,
+  CentralPoint,
+  DeviationAggregate,
+} = wasm;
+
+// basicIndicators namespace — wraps the upstream `basic_indicators` module
+// (mean/median/mode/variance/std-dev/etc.). Mirrors the {single, bulk}
+// pattern used elsewhere in this binding.
+export const basicIndicators = {
+  single: {
+    mean: wasm.basic_single_mean,
+    median: wasm.basic_single_median,
+    mode: wasm.basic_single_mode,
+    logDifference: wasm.basic_single_logDifference,
+    variance: wasm.basic_single_variance,
+    standardDeviation: wasm.basic_single_standardDeviation,
+    absoluteDeviation: wasm.basic_single_absoluteDeviation,
+    logStandardDeviation: wasm.basic_single_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_single_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_single_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_single_cauchyIqrScale,
+    max: wasm.basic_single_max,
+    min: wasm.basic_single_min,
+    priceDistribution: wasm.basic_single_priceDistribution,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_single_empiricalQuantileRangeFromDistribution,
+  },
+  bulk: {
+    mean: wasm.basic_bulk_mean,
+    median: wasm.basic_bulk_median,
+    mode: wasm.basic_bulk_mode,
+    log: wasm.basic_bulk_log,
+    logDifference: wasm.basic_bulk_logDifference,
+    variance: wasm.basic_bulk_variance,
+    standardDeviation: wasm.basic_bulk_standardDeviation,
+    absoluteDeviation: wasm.basic_bulk_absoluteDeviation,
+    priceDistribution: wasm.basic_bulk_priceDistribution,
+    logStandardDeviation: wasm.basic_bulk_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_bulk_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_bulk_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_bulk_cauchyIqrScale,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_bulk_empiricalQuantileRangeFromDistribution,
+  },
+};
 
 // Natural JS/TS namespace mirroring centaur_technical_indicators::candle_indicators::{single, bulk}
 export const candleIndicators = {

--- a/index.node.js
+++ b/index.node.js
@@ -7,7 +7,52 @@ const require = createRequire(import.meta.url);
 const wasm = require("./dist/node/centaur-technical-indicators.js");
 
 // Re-export enums from the wasm module
-export const { ConstantModelType, DeviationModel, Position, MovingAverageType } = wasm;
+export const {
+  ConstantModelType,
+  DeviationModel,
+  Position,
+  MovingAverageType,
+  CentralPoint,
+  DeviationAggregate,
+} = wasm;
+
+export const basicIndicators = {
+  single: {
+    mean: wasm.basic_single_mean,
+    median: wasm.basic_single_median,
+    mode: wasm.basic_single_mode,
+    logDifference: wasm.basic_single_logDifference,
+    variance: wasm.basic_single_variance,
+    standardDeviation: wasm.basic_single_standardDeviation,
+    absoluteDeviation: wasm.basic_single_absoluteDeviation,
+    logStandardDeviation: wasm.basic_single_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_single_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_single_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_single_cauchyIqrScale,
+    max: wasm.basic_single_max,
+    min: wasm.basic_single_min,
+    priceDistribution: wasm.basic_single_priceDistribution,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_single_empiricalQuantileRangeFromDistribution,
+  },
+  bulk: {
+    mean: wasm.basic_bulk_mean,
+    median: wasm.basic_bulk_median,
+    mode: wasm.basic_bulk_mode,
+    log: wasm.basic_bulk_log,
+    logDifference: wasm.basic_bulk_logDifference,
+    variance: wasm.basic_bulk_variance,
+    standardDeviation: wasm.basic_bulk_standardDeviation,
+    absoluteDeviation: wasm.basic_bulk_absoluteDeviation,
+    priceDistribution: wasm.basic_bulk_priceDistribution,
+    logStandardDeviation: wasm.basic_bulk_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_bulk_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_bulk_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_bulk_cauchyIqrScale,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_bulk_empiricalQuantileRangeFromDistribution,
+  },
+};
 
 // Natural JS/TS namespace mirroring centaur_technical_indicators::candle_indicators::{single, bulk}
 export const candleIndicators = {

--- a/index.web.js
+++ b/index.web.js
@@ -1,7 +1,52 @@
 // Browser wrapper: same façade, imports the web target.
 import init, * as wasm from "./dist/web/centaur-technical-indicators.js";
 
-export const { ConstantModelType, DeviationModel, Position, MovingAverageType } = wasm;
+export const {
+  ConstantModelType,
+  DeviationModel,
+  Position,
+  MovingAverageType,
+  CentralPoint,
+  DeviationAggregate,
+} = wasm;
+
+export const basicIndicators = {
+  single: {
+    mean: wasm.basic_single_mean,
+    median: wasm.basic_single_median,
+    mode: wasm.basic_single_mode,
+    logDifference: wasm.basic_single_logDifference,
+    variance: wasm.basic_single_variance,
+    standardDeviation: wasm.basic_single_standardDeviation,
+    absoluteDeviation: wasm.basic_single_absoluteDeviation,
+    logStandardDeviation: wasm.basic_single_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_single_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_single_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_single_cauchyIqrScale,
+    max: wasm.basic_single_max,
+    min: wasm.basic_single_min,
+    priceDistribution: wasm.basic_single_priceDistribution,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_single_empiricalQuantileRangeFromDistribution,
+  },
+  bulk: {
+    mean: wasm.basic_bulk_mean,
+    median: wasm.basic_bulk_median,
+    mode: wasm.basic_bulk_mode,
+    log: wasm.basic_bulk_log,
+    logDifference: wasm.basic_bulk_logDifference,
+    variance: wasm.basic_bulk_variance,
+    standardDeviation: wasm.basic_bulk_standardDeviation,
+    absoluteDeviation: wasm.basic_bulk_absoluteDeviation,
+    priceDistribution: wasm.basic_bulk_priceDistribution,
+    logStandardDeviation: wasm.basic_bulk_logStandardDeviation,
+    studentTAdjustedStd: wasm.basic_bulk_studentTAdjustedStd,
+    laplaceStdEquivalent: wasm.basic_bulk_laplaceStdEquivalent,
+    cauchyIqrScale: wasm.basic_bulk_cauchyIqrScale,
+    empiricalQuantileRangeFromDistribution:
+      wasm.basic_bulk_empiricalQuantileRangeFromDistribution,
+  },
+};
 
 export const candleIndicators = {
   single: {

--- a/src/basic_indicators.rs
+++ b/src/basic_indicators.rs
@@ -1,0 +1,285 @@
+use crate::jsutil::{flat_to_array, js_err, pairs_to_array};
+use js_sys::Array;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+
+// =========================================================================
+// SINGLE
+// =========================================================================
+
+#[wasm_bindgen(js_name = basic_single_mean)]
+pub fn basic_single_mean(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::mean(&prices).map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_median)]
+pub fn basic_single_median(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::median(&prices).map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_mode)]
+pub fn basic_single_mode(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::mode(&prices).map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_logDifference)]
+pub fn basic_single_log_difference(price_t: f64, price_t_1: f64) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::log_difference(price_t, price_t_1)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_variance)]
+pub fn basic_single_variance(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::variance(&prices).map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_standardDeviation)]
+pub fn basic_single_standard_deviation(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::standard_deviation(&prices)
+        .map_err(js_err)
+}
+
+/// Absolute deviation with a configurable center and aggregate.
+/// `AbsDevConfig { center, aggregate }` from the Rust core is flattened to two
+/// positional enum parameters, since `wasm_bindgen` cannot construct the struct
+/// directly from JS. Mirrors the existing flattening pattern used in
+/// `chart_trends_breakDownTrends`.
+#[wasm_bindgen(js_name = basic_single_absoluteDeviation)]
+pub fn basic_single_absolute_deviation(
+    prices: Vec<f64>,
+    center: crate::CentralPoint,
+    aggregate: crate::DeviationAggregate,
+) -> Result<f64, JsValue> {
+    let config = centaur_technical_indicators::AbsDevConfig {
+        center: center.into(),
+        aggregate: aggregate.into(),
+    };
+    centaur_technical_indicators::basic_indicators::single::absolute_deviation(&prices, config)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_logStandardDeviation)]
+pub fn basic_single_log_standard_deviation(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::log_standard_deviation(&prices)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_studentTAdjustedStd)]
+pub fn basic_single_student_t_adjusted_std(
+    prices: Vec<f64>,
+    df: f64,
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::student_t_adjusted_std(&prices, df)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_laplaceStdEquivalent)]
+pub fn basic_single_laplace_std_equivalent(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::laplace_std_equivalent(&prices)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_cauchyIqrScale)]
+pub fn basic_single_cauchy_iqr_scale(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::cauchy_iqr_scale(&prices)
+        .map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_max)]
+pub fn basic_single_max(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::max(&prices).map_err(js_err)
+}
+
+#[wasm_bindgen(js_name = basic_single_min)]
+pub fn basic_single_min(prices: Vec<f64>) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::min(&prices).map_err(js_err)
+}
+
+/// `price_distribution` returns `Vec<(f64, usize)>` upstream — each entry is
+/// `(bucket_center, count)`. Convert to `Array<[number, number]>` with the
+/// `usize` cast to `f64`.
+#[wasm_bindgen(js_name = basic_single_priceDistribution)]
+pub fn basic_single_price_distribution(
+    prices: Vec<f64>,
+    precision: f64,
+) -> Result<Array, JsValue> {
+    let dist = centaur_technical_indicators::basic_indicators::single::price_distribution(
+        &prices, precision,
+    )
+    .map_err(js_err)?;
+    Ok(pairs_to_array(
+        dist.into_iter().map(|(v, c)| (v, c as f64)),
+    ))
+}
+
+#[wasm_bindgen(js_name = basic_single_empiricalQuantileRangeFromDistribution)]
+pub fn basic_single_empirical_quantile_range_from_distribution(
+    prices: Vec<f64>,
+    precision: f64,
+    low: f64,
+    high: f64,
+) -> Result<f64, JsValue> {
+    centaur_technical_indicators::basic_indicators::single::empirical_quantile_range_from_distribution(
+        &prices, precision, low, high,
+    )
+    .map_err(js_err)
+}
+
+// =========================================================================
+// BULK
+// =========================================================================
+
+#[wasm_bindgen(js_name = basic_bulk_mean)]
+pub fn basic_bulk_mean(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::mean(&prices, period)
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_median)]
+pub fn basic_bulk_median(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::median(&prices, period)
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_mode)]
+pub fn basic_bulk_mode(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::mode(&prices, period)
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_log)]
+pub fn basic_bulk_log(prices: Vec<f64>) -> Result<Array, JsValue> {
+    let data =
+        centaur_technical_indicators::basic_indicators::bulk::log(&prices).map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_logDifference)]
+pub fn basic_bulk_log_difference(prices: Vec<f64>) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::log_difference(&prices)
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_variance)]
+pub fn basic_bulk_variance(prices: Vec<f64>, period: usize) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::variance(&prices, period)
+        .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_standardDeviation)]
+pub fn basic_bulk_standard_deviation(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data =
+        centaur_technical_indicators::basic_indicators::bulk::standard_deviation(&prices, period)
+            .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_absoluteDeviation)]
+pub fn basic_bulk_absolute_deviation(
+    prices: Vec<f64>,
+    period: usize,
+    center: crate::CentralPoint,
+    aggregate: crate::DeviationAggregate,
+) -> Result<Array, JsValue> {
+    let config = centaur_technical_indicators::AbsDevConfig {
+        center: center.into(),
+        aggregate: aggregate.into(),
+    };
+    let data = centaur_technical_indicators::basic_indicators::bulk::absolute_deviation(
+        &prices, period, config,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+/// `bulk::price_distribution` returns `Vec<Vec<(f64, usize)>>` — one nested
+/// distribution per window. Convert to `Array<Array<[number, number]>>`.
+#[wasm_bindgen(js_name = basic_bulk_priceDistribution)]
+pub fn basic_bulk_price_distribution(
+    prices: Vec<f64>,
+    period: usize,
+    precision: f64,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::price_distribution(
+        &prices, period, precision,
+    )
+    .map_err(js_err)?;
+    let outer = Array::new();
+    for inner_dist in data {
+        outer.push(&pairs_to_array(
+            inner_dist.into_iter().map(|(v, c)| (v, c as f64)),
+        ));
+    }
+    Ok(outer)
+}
+
+#[wasm_bindgen(js_name = basic_bulk_logStandardDeviation)]
+pub fn basic_bulk_log_standard_deviation(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::log_standard_deviation(
+        &prices, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_studentTAdjustedStd)]
+pub fn basic_bulk_student_t_adjusted_std(
+    prices: Vec<f64>,
+    period: usize,
+    df: f64,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::student_t_adjusted_std(
+        &prices, period, df,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_laplaceStdEquivalent)]
+pub fn basic_bulk_laplace_std_equivalent(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::laplace_std_equivalent(
+        &prices, period,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_cauchyIqrScale)]
+pub fn basic_bulk_cauchy_iqr_scale(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
+    let data =
+        centaur_technical_indicators::basic_indicators::bulk::cauchy_iqr_scale(&prices, period)
+            .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}
+
+#[wasm_bindgen(js_name = basic_bulk_empiricalQuantileRangeFromDistribution)]
+pub fn basic_bulk_empirical_quantile_range_from_distribution(
+    prices: Vec<f64>,
+    period: usize,
+    precision: f64,
+    low: f64,
+    high: f64,
+) -> Result<Array, JsValue> {
+    let data = centaur_technical_indicators::basic_indicators::bulk::empirical_quantile_range_from_distribution(
+        &prices, period, precision, low, high,
+    )
+    .map_err(js_err)?;
+    Ok(flat_to_array(data))
+}

--- a/src/jsutil.rs
+++ b/src/jsutil.rs
@@ -1,0 +1,82 @@
+use js_sys::Array;
+use wasm_bindgen::JsValue;
+
+/// Convert any Rust error type that implements `Display` (typically
+/// `TechnicalIndicatorError`) into a `JsValue` carrying a native JS `Error`.
+/// The error's `Display` message is preserved so JS consumers see e.g.
+/// "Mismatched lengths: highs=5, lows=4" instead of a panic string.
+pub(crate) fn js_err(e: impl std::fmt::Display) -> JsValue {
+    JsValue::from(js_sys::Error::new(&e.to_string()))
+}
+
+pub(crate) fn flat_to_array<I: IntoIterator<Item = f64>>(data: I) -> Array {
+    let out = Array::new();
+    for v in data {
+        out.push(&JsValue::from_f64(v));
+    }
+    out
+}
+
+pub(crate) fn pair_to_array((a, b): (f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr
+}
+
+pub(crate) fn triple_to_array((a, b, c): (f64, f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr.push(&JsValue::from_f64(c));
+    arr
+}
+
+pub(crate) fn quintuple_to_array((a, b, c, d, e): (f64, f64, f64, f64, f64)) -> Array {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(a));
+    arr.push(&JsValue::from_f64(b));
+    arr.push(&JsValue::from_f64(c));
+    arr.push(&JsValue::from_f64(d));
+    arr.push(&JsValue::from_f64(e));
+    arr
+}
+
+pub(crate) fn pairs_to_array<I: IntoIterator<Item = (f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for p in data {
+        outer.push(&pair_to_array(p));
+    }
+    outer
+}
+
+pub(crate) fn triples_to_array<I: IntoIterator<Item = (f64, f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for t in data {
+        outer.push(&triple_to_array(t));
+    }
+    outer
+}
+
+pub(crate) fn quads_to_array<I: IntoIterator<Item = (f64, f64, f64, f64)>>(data: I) -> Array {
+    let outer = Array::new();
+    for (a, b, c, d) in data {
+        let inner = Array::new();
+        inner.push(&JsValue::from_f64(a));
+        inner.push(&JsValue::from_f64(b));
+        inner.push(&JsValue::from_f64(c));
+        inner.push(&JsValue::from_f64(d));
+        outer.push(&inner);
+    }
+    outer
+}
+
+pub(crate) fn quintuples_to_array<I: IntoIterator<Item = (f64, f64, f64, f64, f64)>>(
+    data: I,
+) -> Array {
+    let outer = Array::new();
+    for q in data {
+        outer.push(&quintuple_to_array(q));
+    }
+    outer
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,52 @@ impl From<Position> for centaur_technical_indicators::Position {
     }
 }
 
+/// Central point used by `basic_indicators::absolute_deviation` and related.
+/// Mirrors `centaur_technical_indicators::CentralPoint`.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub enum CentralPoint {
+    Mean,
+    Median,
+    Mode,
+}
+
+impl From<CentralPoint> for centaur_technical_indicators::CentralPoint {
+    fn from(v: CentralPoint) -> Self {
+        match v {
+            CentralPoint::Mean => centaur_technical_indicators::CentralPoint::Mean,
+            CentralPoint::Median => centaur_technical_indicators::CentralPoint::Median,
+            CentralPoint::Mode => centaur_technical_indicators::CentralPoint::Mode,
+        }
+    }
+}
+
+/// How to aggregate a set of absolute deviations.
+/// Mirrors `centaur_technical_indicators::DeviationAggregate`.
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub enum DeviationAggregate {
+    Mean,
+    Median,
+    Mode,
+}
+
+impl From<DeviationAggregate> for centaur_technical_indicators::DeviationAggregate {
+    fn from(v: DeviationAggregate) -> Self {
+        match v {
+            DeviationAggregate::Mean => centaur_technical_indicators::DeviationAggregate::Mean,
+            DeviationAggregate::Median => centaur_technical_indicators::DeviationAggregate::Median,
+            DeviationAggregate::Mode => centaur_technical_indicators::DeviationAggregate::Mode,
+        }
+    }
+}
+
+// Internal helper module — array converters and structured-error adapter.
+// Not exposed via wasm_bindgen; consumed by the binding modules only.
+pub(crate) mod jsutil;
+
 // Mirror Centaur Technical Indicators structure
+pub mod basic_indicators;
 pub mod candle_indicators;
 pub mod chart_trends;
 pub mod correlation_indicators;

--- a/test/basicIndicators.node.test.js
+++ b/test/basicIndicators.node.test.js
@@ -1,0 +1,275 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import init, {
+  basicIndicators,
+  CentralPoint,
+  DeviationAggregate,
+} from "../index.node.js";
+
+await init();
+
+const PRICES = [1.0, 2.0, 3.0, 4.0, 5.0];
+const SAME_VALUES = [3.0, 3.0, 3.0, 3.0, 3.0];
+
+const close = (a, b, tol = 1e-9) => Math.abs(a - b) <= tol;
+const assertClose = (got, want, tol = 1e-9, label = "") =>
+  assert.ok(
+    close(got, want, tol),
+    `${label}: got ${got}, expected ${want} (tol ${tol})`,
+  );
+
+describe("basicIndicators.single", () => {
+  test("mean of [1,2,3,4,5] is 3.0", () => {
+    assertClose(basicIndicators.single.mean(PRICES), 3.0, 1e-12, "mean");
+  });
+
+  test("median of [1,2,3,4,5] is 3.0", () => {
+    assertClose(basicIndicators.single.median(PRICES), 3.0, 1e-12, "median");
+  });
+
+  test("mode of [3,3,3,3,3] is 3.0", () => {
+    assertClose(basicIndicators.single.mode(SAME_VALUES), 3.0, 1e-12, "mode");
+  });
+
+  test("logDifference(3.0, 2.0) = ln(3/2)", () => {
+    const got = basicIndicators.single.logDifference(3.0, 2.0);
+    assertClose(got, Math.log(3.0 / 2.0), 1e-12, "logDifference");
+  });
+
+  test("variance of [1,2,3,4,5] is 2.0 (population)", () => {
+    assertClose(basicIndicators.single.variance(PRICES), 2.0, 1e-12, "variance");
+  });
+
+  test("standardDeviation of [1,2,3,4,5] is sqrt(2)", () => {
+    assertClose(
+      basicIndicators.single.standardDeviation(PRICES),
+      Math.sqrt(2.0),
+      1e-12,
+      "standardDeviation",
+    );
+  });
+
+  test("absoluteDeviation with Mean center + Mean aggregate", () => {
+    // |1-3| + |2-3| + |3-3| + |4-3| + |5-3| = 2+1+0+1+2 = 6 / 5 = 1.2
+    const got = basicIndicators.single.absoluteDeviation(
+      PRICES,
+      CentralPoint.Mean,
+      DeviationAggregate.Mean,
+    );
+    assertClose(got, 1.2, 1e-12, "absoluteDeviation(Mean, Mean)");
+  });
+
+  test("absoluteDeviation with Median center + Median aggregate", () => {
+    // median([1,2,3,4,5]) = 3; abs devs = [2,1,0,1,2]; median of devs = 1
+    const got = basicIndicators.single.absoluteDeviation(
+      PRICES,
+      CentralPoint.Median,
+      DeviationAggregate.Median,
+    );
+    assertClose(got, 1.0, 1e-12, "absoluteDeviation(Median, Median)");
+  });
+
+  test("logStandardDeviation is finite and positive", () => {
+    const got = basicIndicators.single.logStandardDeviation(PRICES);
+    assert.ok(Number.isFinite(got) && got > 0, `logStandardDeviation = ${got}`);
+  });
+
+  test("studentTAdjustedStd matches std for large df", () => {
+    const std = basicIndicators.single.standardDeviation(PRICES);
+    const adjusted = basicIndicators.single.studentTAdjustedStd(PRICES, 1e6);
+    // df→∞ recovers standard deviation
+    assertClose(adjusted, std, 1e-3, "studentTAdjustedStd@large df");
+  });
+
+  test("laplaceStdEquivalent is finite and positive", () => {
+    const got = basicIndicators.single.laplaceStdEquivalent(PRICES);
+    assert.ok(
+      Number.isFinite(got) && got > 0,
+      `laplaceStdEquivalent = ${got}`,
+    );
+  });
+
+  test("cauchyIqrScale is finite and positive", () => {
+    const got = basicIndicators.single.cauchyIqrScale(PRICES);
+    assert.ok(Number.isFinite(got) && got > 0, `cauchyIqrScale = ${got}`);
+  });
+
+  test("max of [1,2,3,4,5] is 5.0", () => {
+    assertClose(basicIndicators.single.max(PRICES), 5.0, 1e-12, "max");
+  });
+
+  test("min of [1,2,3,4,5] is 1.0", () => {
+    assertClose(basicIndicators.single.min(PRICES), 1.0, 1e-12, "min");
+  });
+
+  test("priceDistribution returns Array<[number, number]>", () => {
+    const out = basicIndicators.single.priceDistribution(PRICES, 1.0);
+    assert.ok(Array.isArray(out), "expected array");
+    for (const entry of out) {
+      assert.ok(Array.isArray(entry) && entry.length === 2);
+      assert.equal(typeof entry[0], "number");
+      assert.equal(typeof entry[1], "number");
+    }
+    // Sum of counts equals input length
+    const totalCount = out.reduce((acc, [, c]) => acc + c, 0);
+    assert.equal(totalCount, PRICES.length, "counts should sum to input length");
+  });
+
+  test("empiricalQuantileRangeFromDistribution: IQR of [1,2,3,4] @ p=1.0 is 2.0", () => {
+    // From the Rust crate's #[test] block: q25=1.75, q75=3.25 => IQR=1.5
+    // The upstream test asserts 2.0 with the implementation's linear interpolation.
+    const got = basicIndicators.single.empiricalQuantileRangeFromDistribution(
+      [1.0, 2.0, 3.0, 4.0],
+      1.0,
+      0.25,
+      0.75,
+    );
+    assertClose(got, 2.0, 1e-9, "empiricalQuantileRangeFromDistribution");
+  });
+});
+
+describe("basicIndicators.bulk", () => {
+  test("mean with period 2 returns rolling means", () => {
+    const got = basicIndicators.bulk.mean(PRICES, 2);
+    assert.deepEqual(Array.from(got), [1.5, 2.5, 3.5, 4.5]);
+  });
+
+  test("median with period 3", () => {
+    const got = basicIndicators.bulk.median(PRICES, 3);
+    assert.deepEqual(Array.from(got), [2.0, 3.0, 4.0]);
+  });
+
+  test("mode with period 2 on constant series", () => {
+    const got = basicIndicators.bulk.mode(SAME_VALUES, 2);
+    assert.deepEqual(Array.from(got), [3.0, 3.0, 3.0, 3.0]);
+  });
+
+  test("log = elementwise ln", () => {
+    const got = basicIndicators.bulk.log(PRICES);
+    const expected = PRICES.map((p) => Math.log(p));
+    assert.equal(got.length, expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      assertClose(got[i], expected[i], 1e-12, `log[${i}]`);
+    }
+  });
+
+  test("logDifference returns L-1 values", () => {
+    const got = basicIndicators.bulk.logDifference(PRICES);
+    assert.equal(got.length, PRICES.length - 1);
+    for (let i = 0; i < got.length; i++) {
+      const expected = Math.log(PRICES[i + 1]) - Math.log(PRICES[i]);
+      assertClose(got[i], expected, 1e-12, `logDifference[${i}]`);
+    }
+  });
+
+  test("variance with period 2", () => {
+    // Each window of 2 has variance 0.25 (population: ((xa - mean)^2 + (xb-mean)^2)/2 = 0.25)
+    const got = basicIndicators.bulk.variance(PRICES, 2);
+    assert.equal(got.length, 4);
+    for (let i = 0; i < got.length; i++) {
+      assertClose(got[i], 0.25, 1e-12, `variance[${i}]`);
+    }
+  });
+
+  test("standardDeviation with period 2 is sqrt(0.25) = 0.5", () => {
+    const got = basicIndicators.bulk.standardDeviation(PRICES, 2);
+    for (let i = 0; i < got.length; i++) {
+      assertClose(got[i], 0.5, 1e-12, `standardDeviation[${i}]`);
+    }
+  });
+
+  test("absoluteDeviation with period 3, Mean/Mean", () => {
+    // window [1,2,3]: mean=2, abs devs=[1,0,1], mean=2/3
+    // window [2,3,4]: mean=3, abs devs=[1,0,1], mean=2/3
+    // window [3,4,5]: mean=4, abs devs=[1,0,1], mean=2/3
+    const got = basicIndicators.bulk.absoluteDeviation(
+      PRICES,
+      3,
+      CentralPoint.Mean,
+      DeviationAggregate.Mean,
+    );
+    assert.equal(got.length, 3);
+    for (let i = 0; i < got.length; i++) {
+      assertClose(got[i], 2.0 / 3.0, 1e-12, `absoluteDeviation[${i}]`);
+    }
+  });
+
+  test("priceDistribution nested shape: Array<Array<[number, number]>>", () => {
+    const out = basicIndicators.bulk.priceDistribution(PRICES, 3, 1.0);
+    assert.ok(Array.isArray(out));
+    assert.equal(out.length, 3, "expected 3 windows");
+    for (const inner of out) {
+      assert.ok(Array.isArray(inner));
+      for (const entry of inner) {
+        assert.ok(Array.isArray(entry) && entry.length === 2);
+      }
+    }
+  });
+
+  test("logStandardDeviation with period 3 is finite and positive", () => {
+    const got = basicIndicators.bulk.logStandardDeviation(PRICES, 3);
+    for (const v of got) {
+      assert.ok(Number.isFinite(v) && v > 0, `logStandardDeviation = ${v}`);
+    }
+  });
+
+  test("studentTAdjustedStd with period 3, large df, matches std", () => {
+    const std = basicIndicators.bulk.standardDeviation(PRICES, 3);
+    const adjusted = basicIndicators.bulk.studentTAdjustedStd(PRICES, 3, 1e6);
+    assert.equal(adjusted.length, std.length);
+    for (let i = 0; i < adjusted.length; i++) {
+      assertClose(adjusted[i], std[i], 1e-3, `studentT[${i}]`);
+    }
+  });
+
+  test("laplaceStdEquivalent with period 3 is finite", () => {
+    const got = basicIndicators.bulk.laplaceStdEquivalent(PRICES, 3);
+    for (const v of got) {
+      assert.ok(Number.isFinite(v), `laplaceStdEquivalent = ${v}`);
+    }
+  });
+
+  test("cauchyIqrScale with period 3 is finite", () => {
+    const got = basicIndicators.bulk.cauchyIqrScale(PRICES, 3);
+    for (const v of got) {
+      assert.ok(Number.isFinite(v), `cauchyIqrScale = ${v}`);
+    }
+  });
+
+  test("empiricalQuantileRangeFromDistribution: bulk IQR over [1,2,3,4]@3,1.0,0.25,0.75 = [1.0, 1.0]", () => {
+    // From the Rust crate's #[test] block
+    const got = basicIndicators.bulk.empiricalQuantileRangeFromDistribution(
+      [1.0, 2.0, 3.0, 4.0],
+      3,
+      1.0,
+      0.25,
+      0.75,
+    );
+    assert.deepEqual(Array.from(got), [1.0, 1.0]);
+  });
+});
+
+describe("basicIndicators error paths", () => {
+  test("mean of empty array throws", () => {
+    assert.throws(() => basicIndicators.single.mean([]));
+  });
+
+  test("variance of single element throws", () => {
+    assert.throws(() => basicIndicators.single.variance([1.0]));
+  });
+
+  test("bulk.mean with period > length throws", () => {
+    assert.throws(() => basicIndicators.bulk.mean(PRICES, 10));
+  });
+
+  test("empiricalQuantileRangeFromDistribution with low >= high throws", () => {
+    assert.throws(() =>
+      basicIndicators.single.empiricalQuantileRangeFromDistribution(
+        PRICES,
+        1.0,
+        0.75,
+        0.25,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the JS-bindings roadmap. Closes the longest-standing API coverage gap by wrapping every function in the upstream `basic_indicators` module, adds the missing `CentralPoint`/`DeviationAggregate` enum mirrors, documents the parameterized-variant gaps, and introduces the typed-array TypeScript alias from Codex's C-3.4.

- **3.1 Full `basicIndicators` namespace:** new `src/basic_indicators.rs` with 29 `#[wasm_bindgen]` functions (15 single + 14 bulk). `basicIndicators` namespace added to `index.js`, `index.web.js`, `index.node.js`. `BasicIndicatorsSingle` and `BasicIndicatorsBulk` TypeScript interfaces with full JSDoc. Comprehensive parity test in `test/basicIndicators.node.test.js`.
- **3.1 supporting:** new `CentralPoint` and `DeviationAggregate` `wasm_bindgen` enum mirrors in `src/lib.rs`, used by `absoluteDeviation`. The upstream `AbsDevConfig { center, aggregate }` is flattened to two positional enum parameters since `wasm-bindgen` can't construct the struct.
- **3.2 Parameterized-variant docs:** `ConstantModelType` and `DeviationModel` JSDoc gain `@remarks` blocks listing the variants that cannot be exposed (`PersonalisedMovingAverage`, `CustomAbsoluteDeviation`, `StudentT`, `EmpiricalQuantileRange`).
- **C-3.4 Typed arrays:** new `export type NumericArray = number[] | Float64Array` in `index.d.ts`. Applied throughout the new `BasicIndicators*` interfaces. Existing `*Indicators*` interfaces still use `number[]`; broadening them is a small mechanical follow-up.

## Scope

Modified: `src/lib.rs` (new enums + module registration + `jsutil` module declaration), `index.js`/`web`/`node` (new namespace), `index.d.ts` (new interfaces + alias + JSDoc @remarks), `CHANGELOG.md`.

Added: `src/basic_indicators.rs`, `src/jsutil.rs` (identical to Phase 2's copy — included so this branch builds standalone), `test/basicIndicators.node.test.js`.

Intentionally not changed in this PR:
- The existing `*Indicators*` interfaces still take `number[]` rather than `NumericArray`. Broadening them is a separate mechanical pass that doesn't add semantic value to this PR.
- **3.3 Audit pass:** I ran the diff suggested in the roadmap (`grep -E '^\s*pub fn '` over each module against the binding's `js_name` exports). No additional missing functions surfaced beyond what Phase 3.1 wraps. Documented here rather than as a separate item.

## Compatibility

- 29 new functions and 2 new enums; no existing API touched.
- The new `NumericArray` alias is structurally `number[] | Float64Array`; existing `number[]` callers are unaffected.
- `wasm-bindgen` already accepts `Float64Array` for `Vec<f64>` parameters at runtime, so consumers who were passing `Float64Array` (with `as any`) can now drop the cast for the new functions.

## Validation

Please run locally and report:
- `cargo fmt --all -- --check`
- `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `npm run build`
- `npm test` — expect ~30 new `basicIndicators` test cases on top of existing ~112.

Manual sanity:
- `grep -c '#\[wasm_bindgen' src/basic_indicators.rs` — should be 29.

## Changelog

`Added` (basicIndicators namespace, enums, NumericArray, tests) and `Changed` (JSDoc @remarks) entries under `[Unreleased]`.

## Cross-repo

No impact on `CentaurTechnicalIndicators-Python` or the published `centaur_technical_indicators` crate. Depends on Phase 2 (#18) for the `src/jsutil.rs` module — this branch includes an identical copy so it builds standalone; the maintainer will see a trivial "both added identical file" merge conflict if Phase 2 lands first. Suggested merge order: 0 → 1 → 2 → 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)