### PR TITLE
Phase 4: throw-path coverage + Playwright web smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- `test/chartTrends.node.test.js` and `test/corelationIndicators.node.test.js`:
+  uncommented the existing `assert.throws` blocks and added additional error-path
+  cases (empty arrays, mismatched lengths, period > length). These had been
+  commented out under the prior panic-string-based error model; Phase 2's
+  structured-error refactor makes the thrown errors deterministic and assertable.
+- **Playwright web-target smoke tests** (Task 4.2 + Codex 4.4 ESM CDN):
+  - `e2e/server.mjs`: tiny zero-dep static file server (port 3007).
+  - `e2e/fixtures/wrapper.html`: loads the package via `index.web.js`.
+  - `e2e/fixtures/cdn.html`: mirrors the ESM CDN pattern documented in README
+    (flat `wasm.*` imports from the web-target build).
+  - `e2e/smoke.spec.mjs`: asserts both fixtures compute the expected RSI value
+    against the running WASM in headless Chromium.
+  - `playwright.config.mjs`: spins up the static server via Playwright's
+    `webServer` config; single Chromium project.
+  - `package.json`: adds `@playwright/test` devDep and `test:web` script.
+  - `e2e/` is deliberately outside `test/` so `node --test`'s default recursive
+    discovery does not try to execute the Playwright specs as `node:test` cases.
+
+### Deferred to follow-up
+- **Task 4.3 (model-variant coverage):** broadening every indicator's tests to
+  walk multiple `ConstantModelType` / `DeviationModel` variants is mechanical
+  bulk work (~50-80 new test cases) requiring parity values per case. Out of
+  scope for this PR — will land as a separate focused PR.
+
 ---
 
 ## [1.2.2] - 2026-04-04

--- a/e2e/fixtures/cdn.html
+++ b/e2e/fixtures/cdn.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>web smoke: ESM CDN-style flat import</title>
+  </head>
+  <body>
+    <h1>web smoke fixture: ESM CDN</h1>
+    <p>Mirrors the ESM CDN pattern documented in README — flat
+    <code>wasm.*</code> imports from the web-target build, without going
+    through <code>index.web.js</code>. The Playwright spec asserts
+    <code>window.__result</code>.</p>
+    <script type="module">
+      try {
+        const wasm = await import(
+          "/dist/web/centaur-technical-indicators.js"
+        );
+        await wasm.default();
+        const rsi = wasm.momentum_single_relativeStrengthIndex(
+          [100.2, 100.46, 100.53, 100.38, 100.19],
+          wasm.ConstantModelType.SimpleMovingAverage,
+        );
+        window.__result = { ok: true, rsi };
+      } catch (err) {
+        window.__result = { ok: false, error: String(err) };
+      }
+    </script>
+  </body>
+</html>

--- a/e2e/fixtures/wrapper.html
+++ b/e2e/fixtures/wrapper.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>web smoke: index.web.js wrapper</title>
+  </head>
+  <body>
+    <h1>web smoke fixture: wrapper</h1>
+    <p>This page loads the package via the <code>index.web.js</code> wrapper
+    and computes an RSI. The Playwright spec asserts <code>window.__result</code>.</p>
+    <script type="module">
+      try {
+        const mod = await import("/index.web.js");
+        await mod.default();
+        const rsi = mod.momentumIndicators.single.relativeStrengthIndex(
+          [100.2, 100.46, 100.53, 100.38, 100.19],
+          mod.ConstantModelType.SimpleMovingAverage,
+        );
+        window.__result = { ok: true, rsi };
+      } catch (err) {
+        window.__result = { ok: false, error: String(err) };
+      }
+    </script>
+  </body>
+</html>

--- a/e2e/server.mjs
+++ b/e2e/server.mjs
@@ -1,0 +1,56 @@
+// Tiny static file server for Playwright web-target smoke tests.
+// Serves the repo root so both `/index.web.js` (the wrapper) and
+// `/dist/web/centaur-technical-indicators.js` (the bundler flat export)
+// resolve, along with the .wasm artefact.
+//
+// Runs on port 3007 by default (overridable via PORT env). Logs nothing
+// unless DEBUG=1 to keep Playwright output readable.
+
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { resolve, extname, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(import.meta.url);
+const ROOT = resolve(here, "..", "..");
+
+const MIME = {
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".html": "text/html; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".d.ts": "text/plain; charset=utf-8",
+};
+
+const PORT = Number(process.env.PORT ?? 3007);
+
+const server = createServer(async (req, res) => {
+  try {
+    const requested = decodeURIComponent(req.url.split("?")[0]);
+    const filePath = resolve(ROOT, "." + normalize(requested));
+    if (!filePath.startsWith(ROOT)) {
+      res.writeHead(403).end();
+      return;
+    }
+    const s = await stat(filePath);
+    if (s.isDirectory()) {
+      res.writeHead(404).end();
+      return;
+    }
+    const data = await readFile(filePath);
+    const mime = MIME[extname(filePath)] ?? "application/octet-stream";
+    res.writeHead(200, { "Content-Type": mime, "Cache-Control": "no-store" });
+    res.end(data);
+  } catch {
+    res.writeHead(404).end();
+  }
+});
+
+server.listen(PORT, () => {
+  if (process.env.DEBUG === "1") {
+    console.log(`smoke-server listening on http://localhost:${PORT}`);
+  }
+});

--- a/e2e/smoke.spec.mjs
+++ b/e2e/smoke.spec.mjs
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+
+const EXPECTED_RSI = 49.25373134328325;
+
+test("web target via index.web.js wrapper computes RSI", async ({ page }) => {
+  page.on("pageerror", (err) =>
+    test.info().annotations.push({ type: "pageerror", description: err.message }),
+  );
+  await page.goto("/e2e/fixtures/wrapper.html");
+  await page.waitForFunction(() => window.__result !== undefined, null, {
+    timeout: 30_000,
+  });
+  const result = await page.evaluate(() => window.__result);
+  expect(result.ok, `wrapper fixture errored: ${result.error}`).toBe(true);
+  expect(result.rsi).toBeCloseTo(EXPECTED_RSI, 9);
+});
+
+test("web target via flat ESM CDN-style import computes RSI", async ({
+  page,
+}) => {
+  page.on("pageerror", (err) =>
+    test.info().annotations.push({ type: "pageerror", description: err.message }),
+  );
+  await page.goto("/e2e/fixtures/cdn.html");
+  await page.waitForFunction(() => window.__result !== undefined, null, {
+    timeout: 30_000,
+  });
+  const result = await page.evaluate(() => window.__result);
+  expect(result.ok, `cdn fixture errored: ${result.error}`).toBe(true);
+  expect(result.rsi).toBeCloseTo(EXPECTED_RSI, 9);
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "build:bundler": "wasm-pack build --release --target bundler --out-dir dist/bundler --out-name centaur-technical-indicators && rm -f dist/bundler/.gitignore",
     "build": "npm run build:web && npm run build:node && npm run build:bundler",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node --test"
+    "test": "npm run build && node --test",
+    "test:web": "playwright test --config=playwright.config.mjs"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.46.0"
   },
   "keywords": [
     "rust",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3007;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.spec\.mjs/,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "line",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `node e2e/server.mjs`,
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/test/chartTrends.node.test.js
+++ b/test/chartTrends.node.test.js
@@ -94,13 +94,23 @@ describe("chartTrends (parity with Rust tests)", () => {
     ]);
   });
 
-  // Optional: panic parity checks (commented out by default as they throw)
-  // test("peaks_panic (period > len)", () => {
-  //   const highs = [101.26, 102.57, 102.57, 100.69, 100.83, 101.73, 102.01];
-  //   assert.throws(() => chartTrends.peaks(highs, 40, 1));
-  // });
-  // test("valleys_panic (period > len)", () => {
-  //   const lows = [98.75, 98.75, 100.14, 98.98, 99.07, 100.1, 99.96];
-  //   assert.throws(() => chartTrends.valleys(lows, 40, 1));
-  // });
+  test("peaks: period > length throws", () => {
+    const highs = [101.26, 102.57, 102.57, 100.69, 100.83, 101.73, 102.01];
+    assert.throws(() => chartTrends.peaks(highs, 40, 1));
+  });
+
+  test("valleys: period > length throws", () => {
+    const lows = [98.75, 98.75, 100.14, 98.98, 99.07, 100.1, 99.96];
+    assert.throws(() => chartTrends.valleys(lows, 40, 1));
+  });
+
+  test("peaks: empty array throws", () => {
+    assert.throws(() => chartTrends.peaks([], 3, 1));
+  });
+
+  test("breakDownTrends: empty array throws", () => {
+    assert.throws(() =>
+      chartTrends.breakDownTrends([], 1, 0.5, 0.25, 2.0, 3.0, 0.5, 3.5, 0.25, 3.75),
+    );
+  });
 });

--- a/test/corelationIndicators.node.test.js
+++ b/test/corelationIndicators.node.test.js
@@ -124,12 +124,38 @@ describe("correlationIndicators.bulk (parity with Rust tests)", () => {
     ]);
   });
 
-  // Optional error parity (commented out; will throw)
-  // test("mismatched lengths panic", () => {
-  //   assert.throws(() =>
-  //     correlationIndicators.bulk.correlateAssetPrices(
-  //       [1,2,3], [1,2], ConstantModelType.SimpleMovingAverage, DeviationModel.StandardDeviation, 2
-  //     )
-  //   );
-  // });
+  test("mismatched-lengths bulk call throws", () => {
+    assert.throws(() =>
+      correlationIndicators.bulk.correlateAssetPrices(
+        [1, 2, 3],
+        [1, 2],
+        ConstantModelType.SimpleMovingAverage,
+        DeviationModel.StandardDeviation,
+        2,
+      ),
+    );
+  });
+
+  test("single: empty arrays throw", () => {
+    assert.throws(() =>
+      correlationIndicators.single.correlateAssetPrices(
+        [],
+        [],
+        ConstantModelType.SimpleMovingAverage,
+        DeviationModel.StandardDeviation,
+      ),
+    );
+  });
+
+  test("bulk: period > length throws", () => {
+    assert.throws(() =>
+      correlationIndicators.bulk.correlateAssetPrices(
+        [1, 2, 3, 4],
+        [4, 3, 2, 1],
+        ConstantModelType.SimpleMovingAverage,
+        DeviationModel.StandardDeviation,
+        100,
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the JS-bindings roadmap. Lands the highest-value test-depth items in one focused PR; bulk model-variant coverage (Task 4.3) is deferred to a follow-up.

- **4.1 Throw-path coverage:** uncommented the `assert.throws` blocks in `test/chartTrends.node.test.js` and `test/corelationIndicators.node.test.js`, plus added additional error-path cases (empty array, mismatched lengths, period > length). Was previously dead code under the panic-string error model; Phase 2's structured errors make thrown messages deterministic and worth asserting.
- **4.2 + Codex 4.4 (ESM CDN smoke):** Playwright headless Chromium suite under `e2e/`. Two specs: one through `index.web.js` (the wrapper path), one through the flat `dist/web/centaur-technical-indicators.js` (the ESM CDN pattern from README). Both assert the same RSI parity value.
- Layout: `e2e/` deliberately lives outside `test/` so `node --test`'s default recursive scan does not try to execute the Playwright specs.

## Scope

Modified: `test/chartTrends.node.test.js`, `test/corelationIndicators.node.test.js`, `package.json` (devDep + `test:web` script), `CHANGELOG.md`.

Added: `e2e/server.mjs`, `e2e/smoke.spec.mjs`, `e2e/fixtures/wrapper.html`, `e2e/fixtures/cdn.html`, `playwright.config.mjs`.

Intentionally deferred:
- **Task 4.3 (model-variant coverage):** ~50-80 new test cases per indicator with parity values per variant. Mechanical bulk work that belongs in its own focused follow-up.
- CI integration of `test:web`: the Phase 1 CI rewrite (#17) is the right place to wire this in, after that lands.

## Compatibility

Test-only changes; no runtime behavior change.

## Validation

Please run locally and report:
- `npm install` to fetch Playwright.
- `npx playwright install chromium` (one-time browser fetch).
- `npm run build` (Phase 4 web smoke needs the dist/ artefacts present).
- `npm test` — should now include the uncommented throw blocks.
- `npm run test:web` — Playwright runs the two smoke specs.

## Changelog

`Added` entries under `[Unreleased]`; `Deferred to follow-up` callout for Task 4.3.

## Cross-repo

No impact on `CentaurTechnicalIndicators-Python` or the published `centaur_technical_indicators` crate. Depends on Phase 0 (#16) for the `corelation → correlation` rename (this PR uses the pre-rename filename `corelationIndicators.node.test.js`; the maintainer's merge will need to reconcile). Suggested merge order: 0 → 1 → 2 → 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)