### PR TITLE
Phase 6: enum-variant drift guard (CR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- `test/enumParity.node.test.js`: drift guard that fails fast if the JS-side
+  enum mirror (`src/lib.rs`) drifts from the canonical unit-variant set for
+  any of the six `#[wasm_bindgen]` enums (`ConstantModelType`,
+  `DeviationModel`, `Position`, `MovingAverageType`, `CentralPoint`,
+  `DeviationAggregate`). The check uses
+  `Object.keys(EnumValue).filter(k => Number.isNaN(Number(k))).sort()` to
+  strip wasm-bindgen's reverse-lookup numeric keys, leaving only variant
+  names. Originally CR-1 in the upstream Rust ROADMAP — explicitly delegated
+  to this repo because the variant set is concrete only on the JS side.
+
 ---
 
 ## [1.2.2] - 2026-04-04

--- a/test/enumParity.node.test.js
+++ b/test/enumParity.node.test.js
@@ -1,0 +1,94 @@
+// Enum-variant drift guard.
+//
+// The Rust core defines six enums that this binding mirrors with hand-written
+// wasm_bindgen enums in src/lib.rs (the parameterized variants from the Rust
+// core can't cross the wasm-bindgen boundary, so the JS-side lists are
+// curated unit-variant subsets).
+//
+// Without a guard here, an upstream Rust addition or removal would silently
+// stay behind: the binding compiles, the existing functions still work, and
+// the new variant just wouldn't appear on the JS side. This test fails fast
+// when the JS-side variant set drifts from the expected canonical list.
+//
+// What to do when this test fails:
+//   - If a Rust unit variant was ADDED upstream: mirror it in src/lib.rs's
+//     #[wasm_bindgen] enum (with a matching From<JsEnum> for RustEnum arm),
+//     then add it to the expected list below. Do NOT skip the test.
+//   - If a Rust unit variant was REMOVED upstream: same direction.
+//   - If a Rust parameterized variant was added: do nothing on the JS side
+//     (it can't cross the boundary). Update index.d.ts JSDoc @remarks to
+//     mention the new gap.
+//
+// Why the filter on isNaN(Number(k)): wasm-bindgen exports unit-variant enums
+// as JS objects with BOTH forward (name -> number) and reverse (number-string
+// -> name) entries. Object.keys() gives both. We want only the variant names,
+// which are the keys that aren't parseable as numbers.
+//
+// CR-1 from the Rust ROADMAP delegates this check to this repo (the binding
+// is the only place where the variant set is concretely known on the JS side).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import init, {
+  ConstantModelType,
+  DeviationModel,
+  Position,
+  MovingAverageType,
+  CentralPoint,
+  DeviationAggregate,
+} from "../index.node.js";
+
+await init();
+
+function variantNames(enumValue) {
+  return Object.keys(enumValue)
+    .filter((k) => Number.isNaN(Number(k)))
+    .sort();
+}
+
+test("ConstantModelType has expected unit variants", () => {
+  assert.deepEqual(variantNames(ConstantModelType), [
+    "ExponentialMovingAverage",
+    "SimpleMovingAverage",
+    "SimpleMovingMedian",
+    "SimpleMovingMode",
+    "SmoothedMovingAverage",
+  ]);
+});
+
+test("DeviationModel has expected unit variants", () => {
+  assert.deepEqual(variantNames(DeviationModel), [
+    "CauchyIQRScale",
+    "LaplaceStdEquivalent",
+    "LogStandardDeviation",
+    "MeanAbsoluteDeviation",
+    "MedianAbsoluteDeviation",
+    "ModeAbsoluteDeviation",
+    "StandardDeviation",
+    "UlcerIndex",
+  ]);
+});
+
+test("Position has expected unit variants", () => {
+  assert.deepEqual(variantNames(Position), ["Long", "Short"]);
+});
+
+test("MovingAverageType has expected unit variants", () => {
+  assert.deepEqual(variantNames(MovingAverageType), [
+    "Exponential",
+    "Simple",
+    "Smoothed",
+  ]);
+});
+
+test("CentralPoint has expected unit variants", () => {
+  assert.deepEqual(variantNames(CentralPoint), ["Mean", "Median", "Mode"]);
+});
+
+test("DeviationAggregate has expected unit variants", () => {
+  assert.deepEqual(variantNames(DeviationAggregate), [
+    "Mean",
+    "Median",
+    "Mode",
+  ]);
+});


### PR DESCRIPTION
## Summary

Final phase of the JS-bindings roadmap. Adds the enum-parity drift guard that the upstream Rust ROADMAP (`CR-1`) explicitly delegated to this repo — the JS-side variant set is the concrete artifact that needs guarding, since the Rust core's parameterized variants can't cross the `wasm-bindgen` boundary anyway.

- `test/enumParity.node.test.js`: imports all six `wasm_bindgen` enum mirrors (`ConstantModelType`, `DeviationModel`, `Position`, `MovingAverageType`, `CentralPoint`, `DeviationAggregate`), strips wasm-bindgen's reverse-lookup numeric keys with `Object.keys(...).filter(k => Number.isNaN(Number(k))).sort()`, and `assert.deepEqual` against the canonical unit-variant list per enum.

## Scope

Added: `test/enumParity.node.test.js`. Modified: `CHANGELOG.md`.

No production code changes.

## Compatibility

Test-only. Cannot affect runtime behavior.

## Validation

Please run locally and report: `npm test` should pass (after Phase 3 has landed for the `CentralPoint`/`DeviationAggregate` enums to exist).

I also ran the test-the-test step locally before commit: temporarily mutating one expected list (e.g., removing `"UlcerIndex"` from `DeviationModel`) makes the test fail with a deepEqual diff. Reverted before commit.

## Changelog

`Added` entry under `[Unreleased]`.

## Cross-repo

Originally **CR-1** in `~/Projects/CentaurTechnicalIndicators-Rust/ROADMAP.md`. The upstream ROADMAP explicitly delegates the binding-side enum drift test to this repo because the variant set is concrete only on the JS side.

Depends on Phase 3 (#19) for the `CentralPoint` and `DeviationAggregate` enum mirrors. Suggested merge order: 0 → 1 → 2 → 3 → 4 → 5 → 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)