### PR TITLE
Convert correlationIndicators wrappers to throw JS Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `Result<Array, JsValue>` that carries the upstream `TechnicalIndicatorError`
   message. Adds the shared `src/jsutil.rs` `js_err` adapter. Success behavior
   unchanged.
+- `correlationIndicators` wrappers (`single`/`bulk` `correlateAssetPrices`) now
+  throw a JS `Error` instead of panicking on invalid input; success values
+  unchanged.
 
 ### Removed
 - Consolidated agent/process docs to AGENTS.md + CONTRIBUTING.md (+ new CLAUDE.md pointer); deleted docs/REPO_MAP.md, docs/AI_ONBOARDING.md, AI_FRIENDLY_ROADMAP.md, .github/copilot-instructions.md, ai-policy.yaml.

--- a/src/correlation_indicators.rs
+++ b/src/correlation_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::js_err;
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -9,14 +10,14 @@ pub fn correlation_single_correlate_asset_prices(
     prices_asset_b: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::correlation_indicators::single::correlate_asset_prices(
         &prices_asset_a,
         &prices_asset_b,
         constant_model_type.into(),
         deviation_model.into(),
     )
-    .expect("Failed to correlate asset prices")
+    .map_err(js_err)
 }
 
 /// Rolling correlation over a period: returns Array<number>
@@ -27,7 +28,7 @@ pub fn correlation_bulk_correlate_asset_prices(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::correlation_indicators::bulk::correlate_asset_prices(
         &prices_asset_a,
         &prices_asset_b,
@@ -35,10 +36,10 @@ pub fn correlation_bulk_correlate_asset_prices(
         deviation_model.into(),
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }

--- a/test/corelationIndicators.node.test.js
+++ b/test/corelationIndicators.node.test.js
@@ -124,12 +124,47 @@ describe("correlationIndicators.bulk (parity with Rust tests)", () => {
     ]);
   });
 
-  // Optional error parity (commented out; will throw)
-  // test("mismatched lengths panic", () => {
-  //   assert.throws(() =>
-  //     correlationIndicators.bulk.correlateAssetPrices(
-  //       [1,2,3], [1,2], ConstantModelType.SimpleMovingAverage, DeviationModel.StandardDeviation, 2
-  //     )
-  //   );
-  // });
+  test("mismatched asset-series lengths throw an Error (bulk)", () => {
+    assert.throws(
+      () =>
+        correlationIndicators.bulk.correlateAssetPrices(
+          [1, 2, 3],
+          [1, 2],
+          ConstantModelType.SimpleMovingAverage,
+          DeviationModel.StandardDeviation,
+          2
+        ),
+      (err) => {
+        assert.ok(err instanceof Error, "should be an Error instance");
+        assert.ok(
+          typeof err.message === "string" && err.message.length > 0,
+          "should have a non-empty message"
+        );
+        return true;
+      }
+    );
+  });
+});
+
+describe("correlationIndicators error handling", () => {
+  // A1 (decisive): invalid input throws a catchable Error, not a panic.
+  test("mismatched asset-series lengths throw an Error (single)", () => {
+    assert.throws(
+      () =>
+        correlationIndicators.single.correlateAssetPrices(
+          [1, 2, 3],
+          [1, 2],
+          ConstantModelType.SimpleMovingAverage,
+          DeviationModel.StandardDeviation
+        ),
+      (err) => {
+        assert.ok(err instanceof Error, "should be an Error instance");
+        assert.ok(
+          typeof err.message === "string" && err.message.length > 0,
+          "should have a non-empty message"
+        );
+        return true;
+      }
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Converts the two fallible `.expect(...)` sites in `src/correlation_indicators.rs` into thrown JS `Error`s via `Result<T, JsValue>` and the shared `js_err` helper (PR2). `correlation_single_correlateAssetPrices` now returns `Result<f64, JsValue>` (`.map_err(js_err)`); `correlation_bulk_correlateAssetPrices` returns `Result<Array, JsValue>` (bind core result with `.map_err(js_err)?`, then `Ok(out)`). Success behavior is unchanged — only the failure mode changes from a wasm panic (which poisons the singleton) to a catchable `Error`.

## Scope

- `src/correlation_indicators.rs` — import `crate::jsutil::js_err`; convert the two wrappers.
- `test/corelationIndicators.node.test.js` — add `assert.throws` coverage (single + bulk) for mismatched asset-series lengths; existing parity assertions untouched.
- `CHANGELOG.md` — one bullet under `## [Unreleased]` → `### Changed`.

No other modules, `src/jsutil.rs`, `src/lib.rs`, or `index.*` touched.

## Compatibility

Backward-compatible for valid input (identical return values). The only observable change is that invalid input now throws a JS `Error` instead of panicking. No signature/binding/dependency change.

## Validation

`npm run check` — fmt + strict clippy + triple wasm build + node --test + npm pack — all green (exit 0):

```
> cargo fmt --check && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
    Finished `release` profile [optimized] target(s)   (x3 wasm builds)
ℹ tests 125
ℹ pass 125
ℹ fail 0
npm notice centaur-technical-indicators ... total files: 29
```

## Changelog

> - `correlationIndicators` wrappers (`single`/`bulk` `correlateAssetPrices`) now throw a JS `Error` instead of panicking on invalid input; success values unchanged.

## Acceptance tests

- **A1 (decisive)** — `correlationIndicators error handling > mismatched asset-series lengths throw an Error (single)` ✔ (throws, `instanceof Error`, non-empty message).
- **A1 companion** — `correlationIndicators.bulk > mismatched asset-series lengths throw an Error (bulk)` ✔.
- **A2** — pre-existing `correlationIndicators` parity tests (all `ConstantModelType` / `DeviationModel` variants, single + bulk) pass identically ✔.
- **A3** — pre-PR gates pass; no dependency change ✔.

## Flags

- The test file is misspelled (`corelationIndicators…`, one `r`). Per brief, targeted as-is and NOT renamed — noted for a separate cleanup outside the 1.3.0 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
