### PR TITLE
Error-handling: otherIndicators wrappers throw JS Error on invalid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   of panicking.
 
 ### Changed
+- `otherIndicators` wrappers throw a JS `Error` on invalid input instead of
+  panicking; success values unchanged.
 - Updated `centaur_technical_indicators` from 1.2.2 to 1.3.0.
   - **Behavior change (upstream bug fix), documented per AGENTS.md:** 1.3.0
     fixes `chart_trends::peaks` / `valleys` output on the index-0 and

--- a/src/other_indicators.rs
+++ b/src/other_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::js_err;
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -36,14 +37,14 @@ pub fn other_single_average_true_range(
     high: Vec<f64>,
     low: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::other_indicators::single::average_true_range(
         &close,
         &high,
         &low,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate average true range")
+    .map_err(js_err)
 }
 
 /// internal_bar_strength -> number
@@ -56,11 +57,14 @@ pub fn other_single_internal_bar_strength(high: f64, low: f64, close: f64) -> f6
 
 /// return_on_investment -> Array<[final_value, percent_return]>
 #[wasm_bindgen(js_name = other_bulk_returnOnInvestment)]
-pub fn other_bulk_return_on_investment(prices: Vec<f64>, investment: f64) -> Array {
+pub fn other_bulk_return_on_investment(
+    prices: Vec<f64>,
+    investment: f64,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::return_on_investment(
         &prices, investment,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for (final_value, percent_return) in data {
         let inner = Array::new();
@@ -68,20 +72,24 @@ pub fn other_bulk_return_on_investment(prices: Vec<f64>, investment: f64) -> Arr
         inner.push(&JsValue::from_f64(percent_return));
         out.push(&inner);
     }
-    out
+    Ok(out)
 }
 
 /// true_range -> Array<number>
 #[wasm_bindgen(js_name = other_bulk_trueRange)]
-pub fn other_bulk_true_range(close: Vec<f64>, high: Vec<f64>, low: Vec<f64>) -> Array {
+pub fn other_bulk_true_range(
+    close: Vec<f64>,
+    high: Vec<f64>,
+    low: Vec<f64>,
+) -> Result<Array, JsValue> {
     let data =
         centaur_technical_indicators::other_indicators::bulk::true_range(&close, &high, &low)
-            .expect("Failed to calculate indicator");
+            .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 /// average_true_range -> Array<number>
@@ -92,7 +100,7 @@ pub fn other_bulk_average_true_range(
     low: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::average_true_range(
         &close,
         &high,
@@ -100,26 +108,30 @@ pub fn other_bulk_average_true_range(
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 /// internal_bar_strength -> Array<number>
 #[wasm_bindgen(js_name = other_bulk_internalBarStrength)]
-pub fn other_bulk_internal_bar_strength(high: Vec<f64>, low: Vec<f64>, close: Vec<f64>) -> Array {
+pub fn other_bulk_internal_bar_strength(
+    high: Vec<f64>,
+    low: Vec<f64>,
+    close: Vec<f64>,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::internal_bar_strength(
         &high, &low, &close,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 /// positivity_indicator -> Array<[pi, signal]>
@@ -129,14 +141,14 @@ pub fn other_bulk_positivity_indicator(
     previous_close: Vec<f64>,
     signal_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::other_indicators::bulk::positivity_indicator(
         &open,
         &previous_close,
         signal_period,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for (pi, sig) in data {
         let inner = Array::new();
@@ -144,5 +156,5 @@ pub fn other_bulk_positivity_indicator(
         inner.push(&JsValue::from_f64(sig));
         out.push(&inner);
     }
-    out
+    Ok(out)
 }

--- a/test/otherIndicators.node.test.js
+++ b/test/otherIndicators.node.test.js
@@ -122,3 +122,80 @@ describe("otherIndicators.bulk (parity, one model where applicable)", () => {
     ]);
   });
 });
+
+describe("otherIndicators throws a JS Error on invalid input", () => {
+  const isError = (err) => {
+    assert.ok(err instanceof Error, "thrown value should be instanceof Error");
+    assert.ok(
+      typeof err.message === "string" && err.message.length > 0,
+      "error message should be non-empty"
+    );
+    return true;
+  };
+
+  test("single.averageTrueRange throws on mismatched-length inputs", () => {
+    assert.throws(
+      () =>
+        otherIndicators.single.averageTrueRange(
+          [100.46, 100.53],
+          [101.12],
+          [100.29],
+          ConstantModelType.SimpleMovingAverage
+        ),
+      isError
+    );
+  });
+
+  test("bulk.returnOnInvestment throws on empty prices", () => {
+    assert.throws(
+      () => otherIndicators.bulk.returnOnInvestment([], 1000.0),
+      isError
+    );
+  });
+
+  test("bulk.trueRange throws on mismatched-length inputs", () => {
+    assert.throws(
+      () => otherIndicators.bulk.trueRange([100.46, 100.53], [101.12], [100.29]),
+      isError
+    );
+  });
+
+  test("bulk.averageTrueRange throws on mismatched-length inputs", () => {
+    assert.throws(
+      () =>
+        otherIndicators.bulk.averageTrueRange(
+          [100.46, 100.53],
+          [101.12],
+          [100.29],
+          ConstantModelType.SimpleMovingAverage,
+          3
+        ),
+      isError
+    );
+  });
+
+  test("bulk.internalBarStrength throws on mismatched-length inputs", () => {
+    assert.throws(
+      () =>
+        otherIndicators.bulk.internalBarStrength(
+          [102.32, 100.69],
+          [100.14],
+          [100.55]
+        ),
+      isError
+    );
+  });
+
+  test("positivityIndicator throws on mismatched-length inputs", () => {
+    assert.throws(
+      () =>
+        otherIndicators.bulk.positivityIndicator(
+          [5278.24, 5314.48],
+          [5283.4],
+          5,
+          ConstantModelType.SimpleMovingAverage
+        ),
+      isError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Converts every fallible `.expect(...)` call site in `src/other_indicators.rs`
(6 sites) into a thrown JS `Error` via `Result<T, JsValue>` and the shared
`js_err` helper from `src/jsutil.rs`. On wasm32 (`panic=abort`) a Rust panic
traps the singleton wasm instance; returning `Result` throws a normal
`instanceof Error` and keeps the instance usable. Success behavior unchanged.

## Scope

Converted (now `-> Result<…, JsValue>` with `.map_err(js_err)`):
- `other_single_averageTrueRange` (scalar `-> Result<f64, JsValue>`)
- `other_bulk_returnOnInvestment` (`-> Result<Array, JsValue>`)
- `other_bulk_trueRange`
- `other_bulk_averageTrueRange`
- `other_bulk_internalBarStrength`
- `other_bulk_positivityIndicator`

Infallible functions left untouched (no upstream `Result`):
- `other_single_returnOnInvestment`
- `other_single_trueRange`
- `other_single_internalBarStrength`

Added `use crate::jsutil::js_err;`. All `#[wasm_bindgen(js_name = …)]`
attributes and function names preserved.

## Compatibility

No signature/binding changes to `index.*` or `index.d.ts`. Failure mode only:
invalid input now throws `Error` instead of panicking. Success values are
bit-for-bit identical (parity suite green). No dependency change.

## Validation

`npm run check` (fmt → strict clippy `-D warnings` → triple wasm build →
`node --test` → `npm pack --dry-run`):

```
ℹ tests 129
ℹ suites 18
ℹ pass 129
ℹ fail 0
ℹ skipped 0
```

fmt, clippy (`-D warnings`), bundler/node/web wasm builds, node --test, and
npm pack --dry-run all passed.

## Changelog

Added under `## [Unreleased]` → `### Changed`:
> `otherIndicators` wrappers throw a JS `Error` on invalid input instead of
> panicking; success values unchanged.

## Acceptance tests

- **A1 (decisive)** — new `assert.throws` tests on representative
  `otherIndicators` functions pass: throws, `instanceof Error`, non-empty
  message.
  ```
  ▶ otherIndicators throws a JS Error on invalid input
    ✔ single.averageTrueRange throws on mismatched-length inputs
    ✔ bulk.returnOnInvestment throws on empty prices
    ✔ bulk.trueRange throws on mismatched-length inputs
    ✔ bulk.averageTrueRange throws on mismatched-length inputs
    ✔ bulk.internalBarStrength throws on mismatched-length inputs
    ✔ positivityIndicator throws on mismatched-length inputs
  ✔ otherIndicators throws a JS Error on invalid input
  ℹ pass 15
  ℹ fail 0
  ```
- **A2** — pre-existing `otherIndicators` parity tests still pass identically (included in the 129/0 run above).
- **A3 (suite)** — pre-PR gates pass; no dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)