### PR TITLE
Convert strength_indicators .expect sites to thrown JS Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `Result<Array, JsValue>` that carries the upstream `TechnicalIndicatorError`
   message. Adds the shared `src/jsutil.rs` `js_err` adapter. Success behavior
   unchanged.
+- `strengthIndicators` wrappers throw a JS `Error` instead of panicking on
+  invalid input (via the shared `js_err` helper); success values unchanged.
 
 ### Removed
 - Consolidated agent/process docs to AGENTS.md + CONTRIBUTING.md (+ new CLAUDE.md pointer); deleted docs/REPO_MAP.md, docs/AI_ONBOARDING.md, AI_FRIENDLY_ROADMAP.md, .github/copilot-instructions.md, ai-policy.yaml.

--- a/src/strength_indicators.rs
+++ b/src/strength_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::js_err;
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -41,7 +42,7 @@ pub fn strength_single_relative_vigor_index(
     low: Vec<f64>,
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::strength_indicators::single::relative_vigor_index(
         &open,
         &high,
@@ -49,7 +50,7 @@ pub fn strength_single_relative_vigor_index(
         &close,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate relative vigor index")
+    .map_err(js_err)
 }
 
 // -------- BULK --------
@@ -61,7 +62,7 @@ pub fn strength_bulk_accumulation_distribution(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_accumulation_distribution: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::accumulation_distribution(
         &high,
         &low,
@@ -69,12 +70,12 @@ pub fn strength_bulk_accumulation_distribution(
         &volume,
         previous_accumulation_distribution,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = strength_bulk_positiveVolumeIndex)]
@@ -82,18 +83,18 @@ pub fn strength_bulk_positive_volume_index(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_positive_volume_index: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::positive_volume_index(
         &close,
         &volume,
         previous_positive_volume_index,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = strength_bulk_negativeVolumeIndex)]
@@ -101,18 +102,18 @@ pub fn strength_bulk_negative_volume_index(
     close: Vec<f64>,
     volume: Vec<f64>,
     previous_negative_volume_index: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::negative_volume_index(
         &close,
         &volume,
         previous_negative_volume_index,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = strength_bulk_relativeVigorIndex)]
@@ -123,7 +124,7 @@ pub fn strength_bulk_relative_vigor_index(
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::strength_indicators::bulk::relative_vigor_index(
         &open,
         &high,
@@ -132,10 +133,10 @@ pub fn strength_bulk_relative_vigor_index(
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }

--- a/test/strengthIndicators.node.test.js
+++ b/test/strengthIndicators.node.test.js
@@ -76,3 +76,59 @@ describe("strengthIndicators.bulk (parity, one model where applicable)", () => {
     assert.deepEqual(out, [0.2063784115302081]);
   });
 });
+
+describe("strengthIndicators error handling (throws JS Error)", () => {
+  test("A1 single.relativeVigorIndex throws on mismatched lengths", () => {
+    const open  = [100.73, 99.62, 99.82, 100.38, 100.97, 101.81];
+    const high  = [102.32, 100.69, 100.83, 101.73, 102.01, 102.75];
+    const low   = [100.14, 98.98, 99.07, 100.1, 99.96, 100.55];
+    const close = [100.55, 99.01, 100.43]; // shorter on purpose
+    assert.throws(
+      () =>
+        strengthIndicators.single.relativeVigorIndex(
+          open, high, low, close, ConstantModelType.SimpleMovingAverage
+        ),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.length > 0);
+        return true;
+      }
+    );
+  });
+
+  test("bulk.accumulationDistribution throws on mismatched lengths", () => {
+    const highs = [100.53, 100.68];
+    const lows = [99.62]; // shorter on purpose
+    const close = [100.01, 100.44];
+    const volume = [268.0, 319.0];
+    assert.throws(
+      () =>
+        strengthIndicators.bulk.accumulationDistribution(
+          highs, lows, close, volume, 0.0
+        ),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.length > 0);
+        return true;
+      }
+    );
+  });
+
+  test("bulk.relativeVigorIndex throws on invalid period", () => {
+    const open  = [100.73, 99.62, 99.82, 100.38, 100.97, 101.81];
+    const high  = [102.32, 100.69, 100.83, 101.73, 102.01, 102.75];
+    const low   = [100.14, 98.98, 99.07, 100.1, 99.96, 100.55];
+    const close = [100.55, 99.01, 100.43, 101.0, 101.76, 102.03];
+    assert.throws(
+      () =>
+        strengthIndicators.bulk.relativeVigorIndex(
+          open, high, low, close, ConstantModelType.SimpleMovingAverage, 99
+        ),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.length > 0);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Converts every fallible `.expect(...)` site in `src/strength_indicators.rs` (5 sites) into a thrown JS `Error` via `Result<T, JsValue>` and the shared `js_err` helper (from PR2). Success behavior is unchanged; only the failure mode changes — invalid input now throws a catchable `Error` instead of panicking and poisoning the wasm singleton.

## Scope
- `src/strength_indicators.rs` — added `use crate::jsutil::js_err;`; converted:
  - `strength_single_relativeVigorIndex` (scalar): `-> Result<f64, JsValue>`, `.map_err(js_err)`.
  - `strength_bulk_accumulationDistribution` (Array): `-> Result<Array, JsValue>`, `.map_err(js_err)?` + `Ok(out)`.
  - `strength_bulk_positiveVolumeIndex` (Array): same pattern.
  - `strength_bulk_negativeVolumeIndex` (Array): same pattern.
  - `strength_bulk_relativeVigorIndex` (Array): same pattern.
- Infallible functions left untouched (no `.expect`): `strength_single_accumulationDistribution`, `strength_single_volumeIndex`.
- `test/strengthIndicators.node.test.js` — added an "error handling" describe block with `assert.throws` checks (`instanceof Error`, non-empty message); existing parity assertions retained.
- `CHANGELOG.md` — bullet under `## [Unreleased]` → `### Changed`.

All `js_name`s/attributes preserved; no signatures renamed.

## Compatibility
No binding/signature changes to `index.*` or `index.d.ts`. wasm-bindgen `Result<T, JsValue>` maps to the same JS return type on success; only failure now throws. Backward compatible for all valid inputs.

## Validation
`npm run check` (fmt → strict clippy `-D warnings` → triple wasm build → node --test → npm pack --dry-run):
```
> cargo fmt --check && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings
    Finished `dev` profile ... (no warnings)
    Finished `release` profile ... (bundler/node/web builds)
ℹ tests 126
ℹ pass 126
ℹ fail 0
centaur-technical-indicators-1.2.2.tgz
```
fmt✓ clippy✓ build✓ test✓ pack✓

## Changelog
Added under `[Unreleased]` → `### Changed`:
> `strengthIndicators` wrappers throw a JS `Error` instead of panicking on invalid input (via the shared `js_err` helper); success values unchanged.

## Acceptance tests
- **A1 (decisive)** ✔ `A1 single.relativeVigorIndex throws on mismatched lengths` — throws, `instanceof Error`, non-empty message.
- **A2** ✔ pre-existing `strengthIndicators` parity tests (single + bulk) pass identically.
- **A3** ✔ pre-PR gates green; no dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)