### PR TITLE
momentum_indicators: throw JS Error on invalid input (PR5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   of panicking.
 
 ### Changed
+- `momentumIndicators` wrappers now throw a JS `Error` on invalid input instead
+  of panicking; success values unchanged.
 - Updated `centaur_technical_indicators` from 1.2.2 to 1.3.0.
   - **Behavior change (upstream bug fix), documented per AGENTS.md:** 1.3.0
     fixes `chart_trends::peaks` / `valleys` output on the index-0 and

--- a/src/momentum_indicators.rs
+++ b/src/momentum_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::js_err;
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -7,18 +8,18 @@ use wasm_bindgen::JsValue;
 pub fn momentum_single_relative_strength_index(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::relative_strength_index(
         &prices,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate RSI")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_stochasticOscillator)]
-pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> f64 {
+pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::stochastic_oscillator(&prices)
-        .expect("Failed to calculate stochastic oscillator")
+        .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -26,12 +27,12 @@ pub fn momentum_single_stochastic_oscillator(prices: Vec<f64>) -> f64 {
 pub fn momentum_single_slow_stochastic(
     stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::slow_stochastic(
         &stochastics,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate slow stochastic")
+    .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -39,35 +40,45 @@ pub fn momentum_single_slow_stochastic(
 pub fn momentum_single_slowest_stochastic(
     slow_stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::slowest_stochastic(
         &slow_stochastics,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate slowest stochastic")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_williamsPercentR)]
-pub fn momentum_single_williams_percent_r(high: Vec<f64>, low: Vec<f64>, close: f64) -> f64 {
+pub fn momentum_single_williams_percent_r(
+    high: Vec<f64>,
+    low: Vec<f64>,
+    close: f64,
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::williams_percent_r(
         &high, &low, close,
     )
-    .expect("Failed to calculate Williams %R")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_moneyFlowIndex)]
-pub fn momentum_single_money_flow_index(prices: Vec<f64>, volume: Vec<f64>) -> f64 {
+pub fn momentum_single_money_flow_index(
+    prices: Vec<f64>,
+    volume: Vec<f64>,
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::money_flow_index(&prices, &volume)
-        .expect("Failed to calculate Money Flow Index")
+        .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_rateOfChange)]
-pub fn momentum_single_rate_of_change(current_price: f64, previous_price: f64) -> f64 {
+pub fn momentum_single_rate_of_change(
+    current_price: f64,
+    previous_price: f64,
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::rate_of_change(
         current_price,
         previous_price,
     )
-    .expect("Failed to calculate rate of change")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_onBalanceVolume)]
@@ -76,14 +87,14 @@ pub fn momentum_single_on_balance_volume(
     previous_price: f64,
     current_volume: f64,
     previous_on_balance_volume: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::on_balance_volume(
         current_price,
         previous_price,
         current_volume,
         previous_on_balance_volume,
     )
-    .expect("Failed to calculate On Balance Volume")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_commodityChannelIndex)]
@@ -92,14 +103,14 @@ pub fn momentum_single_commodity_channel_index(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::commodity_channel_index(
         &prices,
         constant_model_type.into(),
         deviation_model.into(),
         constant_multiplier,
     )
-    .expect("Failed to calculate Commodity Channel Index")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_mcginleyDynamicCommodityChannelIndex)]
@@ -108,18 +119,18 @@ pub fn momentum_single_mcginley_dynamic_commodity_channel_index(
     previous_mcginley_dynamic: f64,
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (v, m) = centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_commodity_channel_index(
         &prices,
         previous_mcginley_dynamic,
         deviation_model.into(),
         constant_multiplier,
     )
-    .expect("Failed to calculate McGinley Dynamic CCI");
+    .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(v));
     arr.push(&JsValue::from_f64(m));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = momentum_single_macdLine)]
@@ -128,14 +139,14 @@ pub fn momentum_single_macd_line(
     short_period: usize,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::macd_line(
         &prices,
         short_period,
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate MACD line")
+    .map_err(js_err)
 }
 
 #[allow(deprecated)]
@@ -143,12 +154,12 @@ pub fn momentum_single_macd_line(
 pub fn momentum_single_signal_line(
     macds: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::signal_line(
         &macds,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate signal line")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_mcginleyDynamicMacdLine)]
@@ -157,7 +168,7 @@ pub fn momentum_single_mcginley_dynamic_macd_line(
     short_period: usize,
     previous_short_mcginley: f64,
     previous_long_mcginley: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (macd, short_m, long_m) =
         centaur_technical_indicators::momentum_indicators::single::mcginley_dynamic_macd_line(
             &prices,
@@ -165,12 +176,12 @@ pub fn momentum_single_mcginley_dynamic_macd_line(
             previous_short_mcginley,
             previous_long_mcginley,
         )
-        .expect("Failed to calculate McGinley Dynamic MACD line");
+        .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(macd));
     arr.push(&JsValue::from_f64(short_m));
     arr.push(&JsValue::from_f64(long_m));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = momentum_single_chaikinOscillator)]
@@ -184,7 +195,7 @@ pub fn momentum_single_chaikin_oscillator(
     previous_accumulation_distribution: f64,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (v, ad) = centaur_technical_indicators::momentum_indicators::single::chaikin_oscillator(
         &highs,
         &lows,
@@ -195,11 +206,11 @@ pub fn momentum_single_chaikin_oscillator(
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate Chaikin Oscillator");
+    .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(v));
     arr.push(&JsValue::from_f64(ad));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = momentum_single_percentagePriceOscillator)]
@@ -207,19 +218,19 @@ pub fn momentum_single_percentage_price_oscillator(
     prices: Vec<f64>,
     short_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::percentage_price_oscillator(
         &prices,
         short_period,
         constant_model_type.into(),
     )
-    .expect("Failed to calculate Percentage Price Oscillator")
+    .map_err(js_err)
 }
 
 #[wasm_bindgen(js_name = momentum_single_chandeMomentumOscillator)]
-pub fn momentum_single_chande_momentum_oscillator(prices: Vec<f64>) -> f64 {
+pub fn momentum_single_chande_momentum_oscillator(prices: Vec<f64>) -> Result<f64, JsValue> {
     centaur_technical_indicators::momentum_indicators::single::chande_momentum_oscillator(&prices)
-        .expect("Failed to calculate Chande Momentum Oscillator")
+        .map_err(js_err)
 }
 
 // -------- BULK --------
@@ -228,31 +239,34 @@ pub fn momentum_bulk_relative_strength_index(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::relative_strength_index(
         &prices,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate RSI values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_stochasticOscillator)]
-pub fn momentum_bulk_stochastic_oscillator(prices: Vec<f64>, period: usize) -> Array {
+pub fn momentum_bulk_stochastic_oscillator(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::stochastic_oscillator(
         &prices, period,
     )
-    .expect("Failed to calculate stochastic oscillator values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[allow(deprecated)]
@@ -261,18 +275,18 @@ pub fn momentum_bulk_slow_stochastic(
     stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::slow_stochastic(
         &stochastics,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate slow stochastic values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[allow(deprecated)]
@@ -281,18 +295,18 @@ pub fn momentum_bulk_slowest_stochastic(
     slow_stochastics: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::slowest_stochastic(
         &slow_stochastics,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate slowest stochastic values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_williamsPercentR)]
@@ -301,40 +315,44 @@ pub fn momentum_bulk_williams_percent_r(
     low: Vec<f64>,
     close: Vec<f64>,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::williams_percent_r(
         &high, &low, &close, period,
     )
-    .expect("Failed to calculate Williams %R values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_moneyFlowIndex)]
-pub fn momentum_bulk_money_flow_index(prices: Vec<f64>, volume: Vec<f64>, period: usize) -> Array {
+pub fn momentum_bulk_money_flow_index(
+    prices: Vec<f64>,
+    volume: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::money_flow_index(
         &prices, &volume, period,
     )
-    .expect("Failed to calculate Money Flow Index values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_rateOfChange)]
-pub fn momentum_bulk_rate_of_change(prices: Vec<f64>) -> Array {
+pub fn momentum_bulk_rate_of_change(prices: Vec<f64>) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::rate_of_change(&prices)
-        .expect("Failed to calculate rate of change values");
+        .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_onBalanceVolume)]
@@ -342,18 +360,18 @@ pub fn momentum_bulk_on_balance_volume(
     prices: Vec<f64>,
     volume: Vec<f64>,
     previous_on_balance_volume: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::on_balance_volume(
         &prices,
         &volume,
         previous_on_balance_volume,
     )
-    .expect("Failed to calculate On Balance Volume values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_commodityChannelIndex)]
@@ -363,7 +381,7 @@ pub fn momentum_bulk_commodity_channel_index(
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::commodity_channel_index(
         &prices,
         constant_model_type.into(),
@@ -371,12 +389,12 @@ pub fn momentum_bulk_commodity_channel_index(
         constant_multiplier,
         period,
     )
-    .expect("Failed to calculate CCI values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_mcginleyDynamicCommodityChannelIndex)]
@@ -386,7 +404,7 @@ pub fn momentum_bulk_mcginley_dynamic_commodity_channel_index(
     deviation_model: crate::DeviationModel,
     constant_multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::mcginley_dynamic_commodity_channel_index(
         &prices,
         previous_mcginley_dynamic,
@@ -394,7 +412,7 @@ pub fn momentum_bulk_mcginley_dynamic_commodity_channel_index(
         constant_multiplier,
         period,
     )
-    .expect("Failed to calculate McGinley Dynamic CCI values");
+    .map_err(js_err)?;
     let out = Array::new();
     for (v, m) in data {
         let inner = Array::new();
@@ -402,7 +420,7 @@ pub fn momentum_bulk_mcginley_dynamic_commodity_channel_index(
         inner.push(&JsValue::from_f64(m));
         out.push(&inner);
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_macdLine)]
@@ -412,7 +430,7 @@ pub fn momentum_bulk_macd_line(
     short_period_model: crate::ConstantModelType,
     long_period: usize,
     long_period_model: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::macd_line(
         &prices,
         short_period,
@@ -420,12 +438,12 @@ pub fn momentum_bulk_macd_line(
         long_period,
         long_period_model.into(),
     )
-    .expect("Failed to calculate MACD line values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[allow(deprecated)]
@@ -434,18 +452,18 @@ pub fn momentum_bulk_signal_line(
     macds: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::signal_line(
         &macds,
         constant_model_type.into(),
         period,
     )
-    .expect("Failed to calculate signal line values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_mcginleyDynamicMacdLine)]
@@ -455,7 +473,7 @@ pub fn momentum_bulk_mcginley_dynamic_macd_line(
     previous_short_mcginley: f64,
     long_period: usize,
     previous_long_mcginley: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::mcginley_dynamic_macd_line(
         &prices,
         short_period,
@@ -463,7 +481,7 @@ pub fn momentum_bulk_mcginley_dynamic_macd_line(
         long_period,
         previous_long_mcginley,
     )
-    .expect("Failed to calculate McGinley Dynamic MACD line values");
+    .map_err(js_err)?;
     let out = Array::new();
     for (macd, short_m, long_m) in data {
         let inner = Array::new();
@@ -472,7 +490,7 @@ pub fn momentum_bulk_mcginley_dynamic_macd_line(
         inner.push(&JsValue::from_f64(long_m));
         out.push(&inner);
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_chaikinOscillator)]
@@ -487,7 +505,7 @@ pub fn momentum_bulk_chaikin_oscillator(
     previous_accumulation_distribution: f64,
     short_period_model: crate::ConstantModelType,
     long_period_model: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::chaikin_oscillator(
         &highs,
         &lows,
@@ -499,7 +517,7 @@ pub fn momentum_bulk_chaikin_oscillator(
         short_period_model.into(),
         long_period_model.into(),
     )
-    .expect("Failed to calculate Chaikin Oscillator values");
+    .map_err(js_err)?;
     let out = Array::new();
     for (v, ad) in data {
         let inner = Array::new();
@@ -507,7 +525,7 @@ pub fn momentum_bulk_chaikin_oscillator(
         inner.push(&JsValue::from_f64(ad));
         out.push(&inner);
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_percentagePriceOscillator)]
@@ -516,7 +534,7 @@ pub fn momentum_bulk_percentage_price_oscillator(
     short_period: usize,
     long_period: usize,
     constant_model_type: crate::ConstantModelType,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data =
         centaur_technical_indicators::momentum_indicators::bulk::percentage_price_oscillator(
             &prices,
@@ -524,23 +542,26 @@ pub fn momentum_bulk_percentage_price_oscillator(
             long_period,
             constant_model_type.into(),
         )
-        .expect("Failed to calculate Percentage Price Oscillator values");
+        .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }
 
 #[wasm_bindgen(js_name = momentum_bulk_chandeMomentumOscillator)]
-pub fn momentum_bulk_chande_momentum_oscillator(prices: Vec<f64>, period: usize) -> Array {
+pub fn momentum_bulk_chande_momentum_oscillator(
+    prices: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::momentum_indicators::bulk::chande_momentum_oscillator(
         &prices, period,
     )
-    .expect("Failed to calculate Chande Momentum Oscillator values");
+    .map_err(js_err)?;
     let out = Array::new();
     for v in data {
         out.push(&JsValue::from_f64(v));
     }
-    out
+    Ok(out)
 }

--- a/test/momentumIndicators.node.test.js
+++ b/test/momentumIndicators.node.test.js
@@ -371,3 +371,61 @@ describe("momentumIndicators.bulk (parity, one model each)", () => {
     ]);
   });
 });
+
+// 1.3.0: wrappers now throw a JS `Error` on invalid input instead of panicking.
+describe("momentumIndicators error handling (throws JS Error)", () => {
+  // A1 (decisive): representative scalar wrapper throws a real Error.
+  test("single.relativeStrengthIndex empty array throws Error", () => {
+    assert.throws(
+      () =>
+        momentumIndicators.single.relativeStrengthIndex(
+          [],
+          ConstantModelType.SimpleMovingAverage
+        ),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(typeof err.message === "string" && err.message.length > 0);
+        return true;
+      }
+    );
+  });
+
+  test("single.moneyFlowIndex mismatched series lengths throws Error", () => {
+    assert.throws(
+      () => momentumIndicators.single.moneyFlowIndex([100.2, 100.46], [268]),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(typeof err.message === "string" && err.message.length > 0);
+        return true;
+      }
+    );
+  });
+
+  // Representative Array wrapper: period > length.
+  test("bulk.relativeStrengthIndex period > length throws Error", () => {
+    assert.throws(
+      () =>
+        momentumIndicators.bulk.relativeStrengthIndex(
+          [100.2, 100.46, 100.53],
+          ConstantModelType.SimpleMovingAverage,
+          10
+        ),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(typeof err.message === "string" && err.message.length > 0);
+        return true;
+      }
+    );
+  });
+
+  test("bulk.stochasticOscillator empty array throws Error", () => {
+    assert.throws(
+      () => momentumIndicators.bulk.stochasticOscillator([], 5),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(typeof err.message === "string" && err.message.length > 0);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Converts every fallible `.expect(...)` call site in `src/momentum_indicators.rs`
(32 sites) into a thrown JS `Error` by returning `Result<T, JsValue>` via the
shared `js_err` helper (added by PR2). On wasm32 (`panic=abort`) a Rust panic
traps the singleton wasm instance and poisons later calls; `Result<T, JsValue>`
throws a normal JS `Error` (`instanceof Error`) and keeps the instance usable.
Success behavior is unchanged — only the failure mode changes (panic → clean
throw).

## Scope

- **Sites converted (32):** all `single::*` and `bulk::*` wrappers in
  `momentum_indicators.rs`. Scalar wrappers (`relativeStrengthIndex`,
  `stochasticOscillator`, `slowStochastic`, `slowestStochastic`,
  `williamsPercentR`, `moneyFlowIndex`, `rateOfChange`, `onBalanceVolume`,
  `commodityChannelIndex`, `macdLine`, `signalLine`, `percentagePriceOscillator`,
  `chandeMomentumOscillator` — single) now return `Result<f64, JsValue>`; `Array`
  wrappers (the `mcginleyDynamic*`, both `chaikinOscillator`, and all `bulk::*`)
  now return `Result<Array, JsValue>` via `.map_err(js_err)?` + `Ok(out)`.
- **Infallible functions left untouched:** none — every wrapper in this module
  wrapped a fallible core call (`.expect(...)`), so all 32 were converted.
- **chaikin `#[allow]` status:** PR 8 has merged on `main`; both
  `#[allow(clippy::too_many_arguments)]` attributes on
  `momentum_single_chaikin_oscillator` and `momentum_bulk_chaikin_oscillator`
  were **preserved exactly**. All `#[wasm_bindgen(js_name = …)]` and
  `#[allow(deprecated)]` attributes preserved.
- Added `use crate::jsutil::js_err;`.

## Compatibility

No signature/binding change at the JS layer (`index.*`, `index.d.ts` untouched;
PR2 precedent). Success values are bit-for-bit identical; only invalid inputs
now throw a catchable `Error` instead of trapping the instance. No dependency
change.

## Validation

`npm run check` (cargo fmt --check → strict `cargo clippy ... -D warnings` →
triple wasm build (web/node/bundler) → `node --test` → `npm pack --dry-run`):

```
FMT_OK
clippy: Finished (no warnings, -D warnings clean; chaikin #[allow]s preserved)
build: web + node + bundler all built
ℹ tests 127
ℹ pass 127
ℹ fail 0
npm pack --dry-run: centaur-technical-indicators tarball OK (29 files)
```

Gates: fmt✓ clippy✓ build✓ test✓ pack✓

## Acceptance tests

- **A1 (decisive)** — `single.relativeStrengthIndex empty array throws Error`:
  ```
  ✔ single.relativeStrengthIndex empty array throws Error (0.624547ms)
  ```
  Throws, `instanceof Error`, non-empty message. PASS.
- **A2** — all pre-existing parity + PR4 regression tests pass with identical
  output (127/127 pass, 0 fail). PASS.
- **A3 (suite)** — pre-PR gates pass; strict clippy (`-D warnings`,
  wasm32-unknown-unknown, --all-targets) clean with chaikin `#[allow]`s
  preserved; no dependency change. PASS.

New throws tests (all pass):
```
▶ momentumIndicators error handling (throws JS Error)
  ✔ single.relativeStrengthIndex empty array throws Error
  ✔ single.moneyFlowIndex mismatched series lengths throws Error
  ✔ bulk.relativeStrengthIndex period > length throws Error
  ✔ bulk.stochasticOscillator empty array throws Error
```

## Changelog

Added under `## [Unreleased]` → `### Changed`:
> `momentumIndicators` wrappers now throw a JS `Error` on invalid input instead
> of panicking; success values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)