### PR TITLE
PR5a: candle_indicators error handling — throw JS Error instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `Result<Array, JsValue>` that carries the upstream `TechnicalIndicatorError`
   message. Adds the shared `src/jsutil.rs` `js_err` adapter. Success behavior
   unchanged.
+- `candleIndicators` wrappers now throw a JS `Error` on invalid input instead of
+  panicking: every fallible `.expect(...)` in `src/candle_indicators.rs` becomes
+  `.map_err(js_err)`, returning `Result<f64, JsValue>` / `Result<Array, JsValue>`
+  that carries the upstream error message. Success values, ordering, and warmup
+  are unchanged.
 
 ### Removed
 - Consolidated agent/process docs to AGENTS.md + CONTRIBUTING.md (+ new CLAUDE.md pointer); deleted docs/REPO_MAP.md, docs/AI_ONBOARDING.md, AI_FRIENDLY_ROADMAP.md, .github/copilot-instructions.md, ai-policy.yaml.

--- a/src/candle_indicators.rs
+++ b/src/candle_indicators.rs
@@ -1,3 +1,4 @@
+use crate::jsutil::js_err;
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -8,19 +9,19 @@ pub fn candle_single_moving_constant_envelopes(
     prices: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     difference: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (l, m, u) =
         centaur_technical_indicators::candle_indicators::single::moving_constant_envelopes(
             &prices,
             constant_model_type.into(),
             difference,
         )
-        .expect("Failed to calculate moving constant envelopes");
+        .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_mcginleyDynamicEnvelopes)]
@@ -28,19 +29,19 @@ pub fn candle_single_mcginley_dynamic_envelopes(
     prices: Vec<f64>,
     difference: f64,
     previous_mcginley_dynamic: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (l, m, u) =
         centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_envelopes(
             &prices,
             difference,
             previous_mcginley_dynamic,
         )
-        .expect("Failed to calculate indicator");
+        .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_movingConstantBands)]
@@ -49,19 +50,19 @@ pub fn candle_single_moving_constant_bands(
     constant_model_type: crate::ConstantModelType,
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (l, m, u) = centaur_technical_indicators::candle_indicators::single::moving_constant_bands(
         &prices,
         constant_model_type.into(),
         deviation_model.into(),
         deviation_multiplier,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_mcginleyDynamicBands)]
@@ -70,7 +71,7 @@ pub fn candle_single_mcginley_dynamic_bands(
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
     previous_mcginley_dynamic: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (l, m, u) =
         centaur_technical_indicators::candle_indicators::single::mcginley_dynamic_bands(
             &prices,
@@ -78,12 +79,12 @@ pub fn candle_single_mcginley_dynamic_bands(
             deviation_multiplier,
             previous_mcginley_dynamic,
         )
-        .expect("Failed to calculate indicator");
+        .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_ichimokuCloud)]
@@ -94,7 +95,7 @@ pub fn candle_single_ichimoku_cloud(
     conversion_period: usize,
     base_period: usize,
     span_b_period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (a, b, base, conv, displaced_close) =
         centaur_technical_indicators::candle_indicators::single::ichimoku_cloud(
             &highs,
@@ -104,26 +105,26 @@ pub fn candle_single_ichimoku_cloud(
             base_period,
             span_b_period,
         )
-        .expect("Failed to calculate indicator");
+        .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(a));
     arr.push(&JsValue::from_f64(b));
     arr.push(&JsValue::from_f64(base));
     arr.push(&JsValue::from_f64(conv));
     arr.push(&JsValue::from_f64(displaced_close));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_donchianChannels)]
-pub fn candle_single_donchian_channels(highs: Vec<f64>, lows: Vec<f64>) -> Array {
+pub fn candle_single_donchian_channels(highs: Vec<f64>, lows: Vec<f64>) -> Result<Array, JsValue> {
     let (l, m, u) =
         centaur_technical_indicators::candle_indicators::single::donchian_channels(&highs, &lows)
-            .expect("Failed to calculate indicator");
+            .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_keltnerChannel)]
@@ -134,7 +135,7 @@ pub fn candle_single_keltner_channel(
     constant_model_type: crate::ConstantModelType,
     atr_constant_model_type: crate::ConstantModelType,
     multiplier: f64,
-) -> Array {
+) -> Result<Array, JsValue> {
     let (l, m, u) = centaur_technical_indicators::candle_indicators::single::keltner_channel(
         &highs,
         &lows,
@@ -143,12 +144,12 @@ pub fn candle_single_keltner_channel(
         atr_constant_model_type.into(),
         multiplier,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let arr = Array::new();
     arr.push(&JsValue::from_f64(l));
     arr.push(&JsValue::from_f64(m));
     arr.push(&JsValue::from_f64(u));
-    arr
+    Ok(arr)
 }
 
 #[wasm_bindgen(js_name = candle_single_supertrend)]
@@ -158,7 +159,7 @@ pub fn candle_single_supertrend(
     close: Vec<f64>,
     constant_model_type: crate::ConstantModelType,
     multiplier: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     centaur_technical_indicators::candle_indicators::single::supertrend(
         &highs,
         &lows,
@@ -166,7 +167,7 @@ pub fn candle_single_supertrend(
         constant_model_type.into(),
         multiplier,
     )
-    .expect("Failed to calculate supertrend")
+    .map_err(js_err)
 }
 
 // ------------- BULK -------------
@@ -176,14 +177,14 @@ pub fn candle_bulk_moving_constant_envelopes(
     constant_model_type: crate::ConstantModelType,
     difference: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::moving_constant_envelopes(
         &prices,
         constant_model_type.into(),
         difference,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -192,7 +193,7 @@ pub fn candle_bulk_moving_constant_envelopes(
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_mcginleyDynamicEnvelopes)]
@@ -201,14 +202,14 @@ pub fn candle_bulk_mcginley_dynamic_envelopes(
     difference: f64,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::mcginley_dynamic_envelopes(
         &prices,
         difference,
         previous_mcginley_dynamic,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -217,7 +218,7 @@ pub fn candle_bulk_mcginley_dynamic_envelopes(
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_movingConstantBands)]
@@ -227,7 +228,7 @@ pub fn candle_bulk_moving_constant_bands(
     deviation_model: crate::DeviationModel,
     deviation_multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::moving_constant_bands(
         &prices,
         constant_model_type.into(),
@@ -235,7 +236,7 @@ pub fn candle_bulk_moving_constant_bands(
         deviation_multiplier,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -244,7 +245,7 @@ pub fn candle_bulk_moving_constant_bands(
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_mcginleyDynamicBands)]
@@ -254,7 +255,7 @@ pub fn candle_bulk_mcginley_dynamic_bands(
     deviation_multiplier: f64,
     previous_mcginley_dynamic: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::mcginley_dynamic_bands(
         &prices,
         deviation_model.into(),
@@ -262,7 +263,7 @@ pub fn candle_bulk_mcginley_dynamic_bands(
         previous_mcginley_dynamic,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -271,7 +272,7 @@ pub fn candle_bulk_mcginley_dynamic_bands(
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_ichimokuCloud)]
@@ -282,7 +283,7 @@ pub fn candle_bulk_ichimoku_cloud(
     conversion_period: usize,
     base_period: usize,
     span_b_period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::ichimoku_cloud(
         &highs,
         &lows,
@@ -291,7 +292,7 @@ pub fn candle_bulk_ichimoku_cloud(
         base_period,
         span_b_period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (a, b, base, conv, displaced_close) in data {
         let inner = Array::new();
@@ -302,15 +303,19 @@ pub fn candle_bulk_ichimoku_cloud(
         inner.push(&JsValue::from_f64(displaced_close));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_donchianChannels)]
-pub fn candle_bulk_donchian_channels(highs: Vec<f64>, lows: Vec<f64>, period: usize) -> Array {
+pub fn candle_bulk_donchian_channels(
+    highs: Vec<f64>,
+    lows: Vec<f64>,
+    period: usize,
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::donchian_channels(
         &highs, &lows, period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -319,7 +324,7 @@ pub fn candle_bulk_donchian_channels(highs: Vec<f64>, lows: Vec<f64>, period: us
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_keltnerChannel)]
@@ -331,7 +336,7 @@ pub fn candle_bulk_keltner_channel(
     atr_constant_model_type: crate::ConstantModelType,
     multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::keltner_channel(
         &highs,
         &lows,
@@ -341,7 +346,7 @@ pub fn candle_bulk_keltner_channel(
         multiplier,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for (l, m, u) in data {
         let inner = Array::new();
@@ -350,7 +355,7 @@ pub fn candle_bulk_keltner_channel(
         inner.push(&JsValue::from_f64(u));
         outer.push(&inner);
     }
-    outer
+    Ok(outer)
 }
 
 #[wasm_bindgen(js_name = candle_bulk_supertrend)]
@@ -361,7 +366,7 @@ pub fn candle_bulk_supertrend(
     constant_model_type: crate::ConstantModelType,
     multiplier: f64,
     period: usize,
-) -> Array {
+) -> Result<Array, JsValue> {
     let data = centaur_technical_indicators::candle_indicators::bulk::supertrend(
         &highs,
         &lows,
@@ -370,10 +375,10 @@ pub fn candle_bulk_supertrend(
         multiplier,
         period,
     )
-    .expect("Failed to calculate indicator");
+    .map_err(js_err)?;
     let outer = Array::new();
     for v in data {
         outer.push(&JsValue::from_f64(v));
     }
-    outer
+    Ok(outer)
 }

--- a/test/candleIndicators.node.test.js
+++ b/test/candleIndicators.node.test.js
@@ -251,3 +251,66 @@ describe("candleIndicators.bulk (parity with Rust tests)", () => {
     assert.deepEqual(out, [104.91999999999999, 105.1, 104.382]);
   });
 });
+
+describe("candleIndicators error handling (throws Error, not panic)", () => {
+  const isNonEmptyError = (err) =>
+    err instanceof Error && typeof err.message === "string" && err.message.length > 0;
+
+  test("single.movingConstantEnvelopes throws on empty input", () => {
+    assert.throws(
+      () =>
+        candleIndicators.single.movingConstantEnvelopes(
+          [],
+          ConstantModelType.ExponentialMovingAverage,
+          3.0
+        ),
+      isNonEmptyError
+    );
+  });
+
+  test("single.donchianChannels throws on mismatched high/low lengths", () => {
+    assert.throws(
+      () => candleIndicators.single.donchianChannels([101.26, 102.57], [100.08]),
+      isNonEmptyError
+    );
+  });
+
+  test("single.supertrend throws on empty input", () => {
+    assert.throws(
+      () =>
+        candleIndicators.single.supertrend(
+          [],
+          [],
+          [],
+          ConstantModelType.SimpleMovingAverage,
+          2.0
+        ),
+      isNonEmptyError
+    );
+  });
+
+  test("bulk.movingConstantEnvelopes throws when period exceeds series length", () => {
+    assert.throws(
+      () =>
+        candleIndicators.bulk.movingConstantEnvelopes(
+          [100.46, 100.53, 100.38],
+          ConstantModelType.ExponentialMovingAverage,
+          3.0,
+          5
+        ),
+      isNonEmptyError
+    );
+  });
+
+  test("bulk.donchianChannels throws on mismatched high/low lengths", () => {
+    assert.throws(
+      () =>
+        candleIndicators.bulk.donchianChannels(
+          [101.26, 102.57, 102.32],
+          [100.08, 98.75],
+          2
+        ),
+      isNonEmptyError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Converts every fallible `.expect(...)` call site in `src/candle_indicators.rs`
(16 sites) from a Rust panic into a thrown JS `Error`, by returning
`Result<f64, JsValue>` / `Result<Array, JsValue>` and mapping the core error
through the shared `js_err` helper (from PR 2). On wasm32 (`panic=abort`, no
hook) a panic traps the singleton instance and poisons all later calls;
returning `Result` makes wasm-bindgen throw a normal `Error` and leaves the
instance healthy. Success values, ordering, and warmup are unchanged — only the
failure mode changes (panic → clean throw).

## Scope

- `src/candle_indicators.rs`: added `use crate::jsutil::js_err;`; converted all
  16 fallible sites. Scalar (`candle_single_supertrend`) → `Result<f64, JsValue>`
  with trailing `.map_err(js_err)`. `Array` returns (all envelope/band/channel/
  cloud/supertrend single+bulk wrappers) → `Result<Array, JsValue>` binding the
  core result with `.map_err(js_err)?` and returning `Ok(out)`. All existing
  `#[wasm_bindgen(js_name = …)]` attributes preserved verbatim; nothing renamed.
- **Infallible sites left unchanged:** none — every wrapper in this module wraps
  a core call returning `crate::Result<_>`, so all 16 were fallible and converted.
- `test/candleIndicators.node.test.js`: added 5 `assert.throws` cases (empty
  input, mismatched high/low lengths, oversized period); all existing exact-value
  parity assertions unchanged.
- `CHANGELOG.md`: one bullet under `[Unreleased]` → `### Changed`.

Out of scope (untouched): `src/jsutil.rs`, `src/lib.rs`, other `src/*_indicators.rs`
modules, `index.*` / `index.d.ts` (signatures unchanged), `Cargo.toml`/lockfiles.

## Compatibility

No signature change at the JS/TS boundary (still `number` / array; a JS function
may always throw), so no `.d.ts` edit — same precedent as PR 2. No dependency
change. Backward compatible for all valid inputs.

## Validation

`npm run check` (fmt --check → strict clippy `-D warnings` → triple wasm build
[web/node/bundler] → `node --test` → `npm pack --dry-run`) all green:

```
ℹ tests 128
ℹ pass 128
ℹ fail 0
...
centaur-technical-indicators-1.2.2.tgz
```

## Acceptance tests

- **A1 (decisive)** — PASS: `single.movingConstantEnvelopes throws on empty input`
  (and 4 sibling throws cases) pass; the call throws, the thrown value is
  `instanceof Error`, and its message is non-empty (asserted via the
  `isNonEmptyError` predicate).
  ```
  ▶ candleIndicators error handling (throws Error, not panic)
    ✔ single.movingConstantEnvelopes throws on empty input
    ✔ single.donchianChannels throws on mismatched high/low lengths
    ✔ single.supertrend throws on empty input
    ✔ bulk.movingConstantEnvelopes throws when period exceeds series length
    ✔ bulk.donchianChannels throws on mismatched high/low lengths
  ✔ candleIndicators error handling (throws Error, not panic)
  ```
- **A2** — PASS: all pre-existing `candleIndicators` single/bulk parity tests pass
  with identical exact numeric output (no value drift).
- **A3 (suite)** — PASS: full pre-PR gate green; no dependency change.

## Changelog

Added under `[Unreleased]` → `### Changed`: `candleIndicators` wrappers now throw
a JS `Error` on invalid input instead of panicking; success values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)