### PR TITLE
ci: set minimal GITHUB_TOKEN permissions on workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+# Minimal token scope: these jobs only read the repo (checkout) — no writes.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*.*.*"       # Only publish on version tags, e.g. v1.2.3
 
+# Minimal token scope: checkout reads the repo; npm publish authenticates with
+# NPM_TOKEN, not GITHUB_TOKEN — so the default token needs only read.
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a minimal `permissions: { contents: read }` block to both GitHub Actions workflows, resolving the two CodeQL `actions/missing-workflow-permissions` alerts (medium). Without an explicit block, the `GITHUB_TOKEN` is granted the repository's broad default scopes; these workflows only need read.

## Scope
- `.github/workflows/ci.yml` — top-level `permissions: { contents: read }` (the `build-and-test` matrix only checks out + builds + tests).
- `.github/workflows/publish.yml` — same (checkout + build + `npm publish`; npm auth uses `NPM_TOKEN`, not `GITHUB_TOKEN`).

No job logic, triggers, or steps changed. No source/package files touched.

## Compatibility
None. CI/release-infrastructure only; no effect on the published package, its API, or its behavior. `contents: read` is sufficient for `actions/checkout` on a public repo and for the npm publish flow (which authenticates via `NPM_TOKEN`).

## Validation
- Both files parse as YAML with `permissions: {contents: read}` and their original jobs intact (`build-and-test`, `publish`).
- Resolves CodeQL alerts #6 (`ci.yml`) and #1 (`publish.yml`), rule `actions/missing-workflow-permissions`.

## Changelog
Exempt per `AGENTS.md` — CI/internal change with no user-facing effect on the published package (no `CHANGELOG.md` entry).

## Flagged items
- Both workflows are hardened to `contents: read`. If a future change needs the workflow to write (e.g. create a GitHub Release on tag, or comment on PRs), it must add the specific scope back at the job level. None is needed today.
