### PR TITLE
chore(release): cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-21
+
 ### Added
 - Binding registry (`docs/binding_registry.json`) plus a cross-entry-point drift
   test (`test/bindingRegistry.node.test.js`) asserting the public namespace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaur-technical-indicators"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 description = "WASM bindings for Centaur Technical Indicators for Node and browser"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centaur-technical-indicators",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "WASM bindings for Centaur Technical Indicators for Node and browser",
   "author": "ChironMind",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Cuts the **1.3.0** release: bumps the package + crate versions, finalizes the changelog, and reopens an empty `[Unreleased]`. Release mechanics only — no behavioral or API change. This is **Wave D** of the 1.3.0 plan (brief: `docs/dev/releases/1.3.0/briefs/version-cut.md`); it lands after every error-handling PR (PR 2 + 5a–5h), favorable-move (PR 3), CJS (PR 7), and the registry (PR 9).

## Scope
Diff is exactly three files:
- `package.json` — `version` `1.2.2` → `1.3.0`.
- `Cargo.toml` — `[package].version` `1.2.2` → `1.3.0`. The `centaur_technical_indicators = "=1.3.0"` dependency pin is **unchanged**.
- `CHANGELOG.md` — `## [Unreleased]` → `## [1.3.0] - 2026-06-21`, with a fresh empty `## [Unreleased]` reopened above it (all accumulated entries preserved).

No `src/**`, `index.*`, `index.d.ts`, or README changes. (The two README `@1.2.2` references are a prose comment and a commented-out import — optional cosmetics, intentionally left out of the version sweep per the brief.)

## Compatibility
Release mechanics only; no API, binding, type-definition, or behavior change. The published 1.3.0 surface is exactly what landed across PRs 1–9.

## Validation
`npm run check` (fmt + clippy + build + test + pack) — **exit 0**:
- `cargo fmt --check` clean; `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings` clean (`Finished dev profile`).
- `npm run build` — 3 wasm targets built.
- `npm run test:node` — **174 tests, 174 pass, 0 fail**.
- `npm pack --dry-run` — `version: 1.3.0`, `filename: centaur-technical-indicators-1.3.0.tgz`, **29 files**, including `index.node.cjs` and all five entry points (`index.js`, `index.node.js`, `index.web.js`, `index.node.cjs`, `index.d.ts`).

Acceptance tests:
- **A1** ✓ — `require('./package.json').version` → `1.3.0`; `Cargo.toml [package].version` → `1.3.0`; CHANGELOG top released section `## [1.3.0] - 2026-06-21` with an empty `## [Unreleased]` above.
- **A2** ✓ — pack lists `index.node.cjs` and reports `1.3.0` (above).
- **A3** ✓ — gates green; diff limited to `package.json`, `Cargo.toml`, `CHANGELOG.md`.

## Changelog
`## [Unreleased]` finalized to `## [1.3.0] - 2026-06-21` (entries from PRs 1–9 preserved beneath); empty `## [Unreleased]` reopened above.

## Flagged items
- ⚠️ **Tag/publish is deferred and gated.** `git tag v1.3.0 && git push origin v1.3.0` triggers `publish.yml` → `npm publish`. Do **not** tag until this PR (and ideally the workflow-permissions hardening, #46) are merged, and only with explicit approval.
- README `@1.2.2` prose/commented refs left as-is (out of scope per brief).
