### PR TITLE
docs: default npm version badge color + fix License badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://img.shields.io/npm/v/centaur-technical-indicators?color=cb3837&logo=npm)](https://www.npmjs.com/package/centaur-technical-indicators)
+[![npm version](https://img.shields.io/npm/v/centaur-technical-indicators?logo=npm)](https://www.npmjs.com/package/centaur-technical-indicators)
 [![npm downloads](https://img.shields.io/npm/dm/centaur-technical-indicators?logo=npm)](https://www.npmjs.com/package/centaur-technical-indicators)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/centaur-technical-indicators?label=min+zip&logo=webpack)](https://bundlephobia.com/package/centaur-technical-indicators)
 [![Node](https://img.shields.io/badge/Node-%3E%3D20-339933?logo=node.js&logoColor=white)](#)
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/Types-Included-3178C6?logo=typescript&logoColor=white)](#)
 [![Docs](https://img.shields.io/badge/docs-TypeDoc-blue?logo=githubpages)](https://chironmind.github.io/CentaurTechnicalIndicators-JS/)
 [![CI](https://github.com/chironmind/CentaurTechnicalIndicators-JS/actions/workflows/ci.yml/badge.svg)](https://github.com/chironmind/CentaurTechnicalIndicators-JS/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE-MIT)
 
 # CentaurTechnicalIndicators-JS
 


### PR DESCRIPTION
## Summary
Two README badge fixes:
1. **npm version badge** — drop the hardcoded `?color=cb3837` (npm brand red) so it uses shields.io's **default color**. It was rendering red permanently regardless of state, which reads as "error/failure" for a perfectly healthy package (it only shows the published version).
2. **License badge link** — point it at `LICENSE-MIT` (the actual file). It previously linked to `LICENSE`, which doesn't exist → 404 (ROADMAP C-0.6).

## Scope
`README.md` lines 1 and 10 only. No code, no package behavior change.

## Compatibility
None — cosmetic/doc-link fixes.

## Validation
The **CI** Actions badge (separate, line 9) is green/passing on `main`; it was never the red one. Diff is the two badge lines.

## Changelog
Exempt per `AGENTS.md` — cosmetic README changes, no user-facing package effect.

## Flagged items
None.