### PR TITLE
ci: publish via npm Trusted Publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,14 @@ name: Publish to npm
 on:
   push:
     tags:
-      - "v*.*.*"       # Only publish on version tags, e.g. v1.2.3
+      - "v*.*.*"       # Publish on version tags, e.g. v1.2.3
+  workflow_dispatch:    # Manual re-publish of the current package.json version (no re-tag needed)
 
-# Minimal token scope: checkout reads the repo; npm publish authenticates with
-# NPM_TOKEN, not GITHUB_TOKEN — so the default token needs only read.
+# Trusted Publishing (OIDC): id-token lets npm mint a short-lived credential at
+# publish time — no stored NPM_TOKEN to expire or leak. contents:read is for checkout.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -21,8 +23,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+
+      - name: Update npm (Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Set up Rust (for WASM build)
         run: |
@@ -39,7 +44,8 @@ jobs:
       - name: Build WASM targets
         run: npm run build
 
-      - name: Publish to npm
+      # Authenticates via OIDC against the npm Trusted Publisher configured for this
+      # package (GitHub Actions → chironmind/CentaurTechnicalIndicators-JS, publish.yml).
+      # No NODE_AUTH_TOKEN; npm generates build provenance automatically.
+      - name: Publish to npm (Trusted Publishing / OIDC)
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Migrates `publish.yml` from the stored `NPM_TOKEN` to **npm Trusted Publishing (OIDC)**. The token expired and silently blocked the `v1.3.0` publish (npm returned `404` on `PUT` — its signature for invalid auth), so npm `latest` is still `1.2.1`. OIDC removes the token entirely — nothing to expire or leak — and adds build provenance. Part of the **1.3.1** release (brief: `docs/dev/releases/1.3.1/briefs/release-1.3.1.md`, PR #50).

## Scope
`.github/workflows/publish.yml` only:
- `permissions`: add `id-token: write` (keep `contents: read`).
- `on`: add `workflow_dispatch` (re-publish the current `package.json` version with no re-tag).
- `setup-node`: `node-version: 24` + `npm install -g npm@latest` (OIDC trusted publishing needs npm ≥ 11.5.1).
- Publish step: remove `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`; `npm publish --access public` now authenticates via OIDC, provenance automatic.

## Compatibility
No package/API change. Release-infrastructure only.

## ⚠️ Required before this can publish (maintainer, one-time)
Configure the npm **Trusted Publisher** on the package: **Settings → Trusted Publishing → GitHub Actions** → org `chironmind`, repo `CentaurTechnicalIndicators-JS`, workflow `publish.yml` (environment blank). Without it, the OIDC publish fails (stop-and-report, no token fallback).

## Validation
YAML parses; `permissions` = `{contents: read, id-token: write}`; triggers = `push (tags)` + `workflow_dispatch`; the `NODE_AUTH_TOKEN` env is removed. End-to-end verified by the 1.3.1 publish (gated, after merge + the npm-side config).

## Changelog
Exempt per `AGENTS.md` — CI/release-infra change, no user-facing package effect.

## Flagged items
- `secrets.NPM_TOKEN` becomes unused after this merges; it can be deleted from repo secrets once a tokenless publish is confirmed.