### PR TITLE
ci: add Dependabot config (GitHub Actions + npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned in ci.yml / publish.yml current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  # Keep npm devDependencies current.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` — monthly update checks for GitHub Actions (`ci.yml` / `publish.yml`) and npm devDependencies. Complements the 1.3.1 supply-chain theme (Trusted Publishing + the PR #46 `GITHUB_TOKEN` hardening). ROADMAP 1.6; part of the 1.3.1 release (brief PR #50).

## Scope
- Adds `.github/dependabot.yml` (github-actions + npm ecosystems). No code change.
- Intentionally **omits the cargo ecosystem**: the `centaur_technical_indicators` dependency is exact-pinned (`=1.3.0`) on purpose, so version-bump PRs there would be noise; Dependabot *security alerts* cover the dependency graph independently of this file.

## Compatibility
None — repo tooling only.

## Validation
YAML parses; `version: 2`, ecosystems `[github-actions, npm]`.

## Changelog
Exempt per `AGENTS.md` — repo/CI config, no user-facing package effect.

## Flagged items
None.