### PR TITLE
chore(release): cut 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-21
+
+### Changed
+- **Maintenance/release-only — no library or API changes from 1.3.0.** 1.3.0 was
+  never published to npm (a publishing-auth failure on the tag), so 1.3.1 is the
+  first npm release of the 1.3.0 change set: npm upgrades **1.2.1 → 1.3.1** and
+  gains everything listed under [1.3.0] below. npm publishing now uses Trusted
+  Publishing (OIDC) instead of a stored token.
+
 ## [1.3.0] - 2026-06-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaur-technical-indicators"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "WASM bindings for Centaur Technical Indicators for Node and browser"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.1"
 edition = "2021"
 description = "WASM bindings for Centaur Technical Indicators for Node and browser"
 license = "MIT"
-repository = "https://github.com/ChironMind/CentaurTechnicalIndicators-JS"
+repository = "https://github.com/chironmind/CentaurTechnicalIndicators-JS"
 publish = false
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ChironMind/CentaurTechnicalIndicators-JS"
+    "url": "https://github.com/chironmind/CentaurTechnicalIndicators-JS"
   },
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centaur-technical-indicators",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "WASM bindings for Centaur Technical Indicators for Node and browser",
   "author": "ChironMind",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Cuts **1.3.1** — the first npm publish of the 1.3.0 change set (the `v1.3.0` tag's publish failed on an expired token, so npm `latest` is still `1.2.1`). Release mechanics only; no library/API change. Part of the 1.3.1 release (brief: PR #50).

## Scope
Exactly three files:
- `package.json` — `1.3.0` → `1.3.1`.
- `Cargo.toml` — `[package].version` `1.3.0` → `1.3.1` (the `=1.3.0` dependency pin unchanged).
- `CHANGELOG.md` — new `## [1.3.1] - 2026-06-21` (maintenance/release note) above the preserved `## [1.3.0]`; empty `## [Unreleased]` reopened.

No `src/**`, `index.*`, `index.d.ts`, or README changes.

## Compatibility
None — release mechanics only. The published 1.3.1 surface equals 1.3.0's code.

## Validation
`npm run check` (fmt + clippy + build + test + pack) — exit 0:
- `cargo fmt --check` clean; `cargo clippy … -D warnings` clean.
- `npm run build` — 3 wasm targets.
- `npm run test:node` — **174 / 174 pass**.
- `npm pack --dry-run` — `version: 1.3.1`, `centaur-technical-indicators-1.3.1.tgz`, 29 files incl. `index.node.cjs`.

## Changelog
`[Unreleased]` → `## [1.3.1] - 2026-06-21`; empty `[Unreleased]` reopened.

## Flagged items
- ⚠️ **Tag/publish deferred + gated.** After this and the sibling 1.3.1 PRs merge, *and* the npm Trusted Publisher is configured, publishing is `git tag v1.3.1 && git push origin v1.3.1` (or the `workflow_dispatch`) → OIDC publish. Human-approved.