### PR TITLE
docs: make agent guidance self-contained (no workspace refs, no PII)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,92 +1,144 @@
 # AGENTS.md
 
-Guidance for coding agents working in this repository.
+Guidance for coding agents working in this repository. **This file is
+self-contained** — everything needed to work here lives in this repo (this file,
+`CLAUDE.md`, `CONTRIBUTING.md`, and the README); it depends on no external or
+workspace-level file.
 
 ## Scope
-This file applies to the entire repository.
-This is an open source repository; all contributions should be suitable for public review and distribution.
-This file is the self-contained source of truth for this repository's contribution mechanics (branch/commit/PR conventions, gates, scope discipline); it does not depend on any workspace-level file.
+
+Applies to the entire repository. This is a public, open-source package — wasm-pack
+bindings (published to npm) over the `centaur_technical_indicators` Rust core crate;
+all contributions must be suitable for public review and distribution.
+
+## How work arrives
+
+**If your task is a slice brief**, it is self-contained — read it and do exactly
+that. You don't need to read the implementation plan or any project spec to execute
+it; everything required is in the brief. If you hit a real gap, **stop and ask** —
+you'll be pointed at the specific file, never told to read a whole plan. Not every
+task is a brief; for ad-hoc work, follow the standing rules below. (Reviewers are
+the exception — a plan or PR review legitimately reads the plan and spec.)
 
 ## Core contribution requirements
+
 When implementing or modifying WASM bindings or JS/TS wrappers:
 
-1. Export new bindings in **all three** entry points: `index.js` (bundler / ESM `import`), `index.node.js` (CommonJS `require`), and `index.web.js` (browser). `package.json` `exports` maps `import` → `index.js`, `require` → `index.node.js`, `browser` → `index.web.js`.
-2. Update `index.d.ts` with accurate TypeScript signatures and JSDoc for any new or changed public APIs (this is the published types surface).
-3. Add or adjust tests in `test/` for every user-facing change; tests must use exact numeric comparisons for parity with Rust.
-4. Do not introduce deprecated API usage in new examples or tests.
-5. Add an entry for every user-facing change in `CHANGELOG.md` under the `## [Unreleased]` heading, following Keep a Changelog (categories: Added, Changed, Deprecated, Removed, Fixed, Security); name the concrete artifact. A CHANGELOG entry is **not** required for changes with no user-facing effect — tests-only, internal/process docs, or formatting-only — note the exception in the PR's Flagged items.
+1. Export new bindings in **all three** entry points: `index.js` (bundler / ESM
+   `import`), `index.node.js` (CommonJS `require`), and `index.web.js` (browser).
+2. Update `index.d.ts` with accurate TypeScript signatures and JSDoc for any new or
+   changed public API (this is the published types surface).
+3. Add or adjust tests in `test/` for every user-facing change; tests use **exact
+   numeric comparisons** for parity with Rust.
+4. No deprecated API usage in new examples or tests.
+5. Add a `CHANGELOG.md` entry for every user-facing change (see Changelog coupling).
 
-**API shape:** each indicator namespace mirrors two styles — `single.*` (full-window, returns a scalar/tuple) and `bulk.*` (rolling-window, returns arrays). See `CONTRIBUTING.md` for the namespace list.
+**API shape:** each indicator namespace mirrors two styles — `single.*` (full-window)
+and `bulk.*` (rolling-window). **Error model:** validation failures surface as thrown
+JS exceptions (Rust panics propagated by wasm-bindgen); the NaN-vs-throw and
+empty-return semantics (e.g. all-NaN `chartTrends.peaks`/`valleys` returns `[]`) are
+locked by regression tests — preserve them.
 
-**Error model:** validation failures surface as thrown JS exceptions (Rust panics propagated by wasm-bindgen), mirroring the core library's validations (length mismatches, empty arrays, period bounds). NaN-vs-throw and empty-return semantics are part of the contract and are locked by regression tests (e.g. all-NaN `chartTrends.peaks`/`valleys` returns `[]` rather than throwing) — preserve them.
+## Downstream & cross-repo impact
 
-## Change scope discipline
-- Keep changes minimal and focused on the requested task.
-- Do not include opportunistic refactors unless explicitly requested.
-- If you identify unrelated issues, note them separately instead of bundling them into the same change.
-- Preserve existing file organization and naming conventions unless the task requires a structural change.
-- Do not hand-edit generated output: `dist/**` is wasm-pack output (built by `npm run build`) and is `.gitignore`d — never edit it by hand or commit it.
-- Do not reformat unrelated code; no global/repo-wide reformat outside an explicit formatting task.
-- Lockfiles: neither `Cargo.lock` nor `package-lock.json` is git-tracked here (both exist on disk but are untracked and are **not** in `.gitignore`). Do not `git add` them, `dist/`, or other generated artifacts — stage only the files the task names (a blanket `git add -A` could newly introduce the untracked lockfiles).
+This is a binding over the published `centaur_technical_indicators` core crate — the
+core is the source of truth for indicator behavior; mirror its API. Changes here are
+user-facing on npm (including the `index.d.ts` types surface) — document them. Don't
+make cross-repo or architectural decisions from inside this repo; surface them to the
+maintainer.
 
-## Backward compatibility rules
-When changing public APIs, preserve compatibility unless the task explicitly allows a breaking change:
+## Change-scope discipline
+
+- Smallest safe diff that solves the task; keep it focused.
+- No opportunistic refactors or "while I was here" changes — note unrelated issues
+  separately, don't bundle them.
+- Preserve existing file organization and naming unless the task requires a structural change.
+- **Stage only the files your task names; never `git add .` / `git add -A`** —
+  `dist/**` is wasm-pack output (built by `npm run build`, `.gitignore`d; never edit
+  or commit by hand), and neither `Cargo.lock` nor `package-lock.json` is tracked
+  (both exist on disk but untracked). The committed decision trail under
+  `docs/dev/releases/<version>/` (PR briefs in `briefs/`, `version-cut.md`, any
+  `RESUME.md`) is intentional — commit those when your task creates or updates them.
+- Never hand-edit a generated artifact or a test expectation to make a gate pass. A
+  test value that needs changing is a signal to **stop and report**.
+
+## Backward compatibility
+
+Published public APIs — treat them as a contract:
 
 1. Do not silently change indicator semantics, output ordering, or warmup behavior.
 2. Do not remove or rename public functions, types, or enums without explicit approval.
-3. If behavior changes are required, document them in `index.d.ts` JSDoc and `CHANGELOG.md` with clear migration notes.
-
-## Branch naming
-- Never commit directly to `main`; branch first. PRs target `main`.
-- Stacked-PR branches use `pr/<n>-<slug>`, where `<n>` is the PR number and `<slug>` is a short kebab-case description (e.g. `pr/7-cjs-export`, `pr/2-chart-trends-errors`); letter-suffixed sub-PRs are allowed (e.g. `pr/6b-doc-consolidation`).
-- Before a PR number exists, branch with a descriptive `<type>/<slug>` (conventional-commit type: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `ci`), e.g. `docs/agents-alignment`; rename to `pr/<n>-<slug>` once the PR is opened if adopting the stacked scheme.
-- Reserved prefixes: `release/<x.y.z>` for release branches, `docs/<slug>` for docs/archive-only branches.
-- Legacy `copilot/*` and dash-form `release-x.y.z` branches predate this scheme — do not extend them.
-
-## Commit messages
-- Use conventional-commit prefixes: `fix:`, `feat:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:` (scopes allowed, e.g. `feat(chart_trends):`; `style:` / `ci:` where apt). Keep the subject under 72 characters; reference PR/issue numbers where applicable.
-- End every commit authored with Claude Code with this trailer on its own final line:
-  ```text
-  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
-  ```
-  Existing lowercase `Co-authored-by:` lines for human or bot co-authors are unaffected.
+3. If a behavior change is required, document it in `index.d.ts` JSDoc and `CHANGELOG.md` with migration notes.
 
 ## Pre-PR quality gates (must pass)
-Run these locally before opening a PR. Only `npm run build` and `node --test` are CI-enforced (via `npm test`); `cargo fmt` and `cargo clippy` are local/honor-system here.
+
+Run these before opening a PR; paste the output into the report's Validation section.
+Only `npm run build` and `node --test` are CI-enforced (via `npm test`); `cargo fmt`
+and `cargo clippy` are local/honor-system here:
 
 1. `cargo fmt --check` — no Rust formatting diffs.
 2. `cargo clippy --all-targets --all-features -- -D warnings` — zero Rust warnings/errors.
-3. `npm run build` — builds all three WASM targets. Expands to `build:web && build:node && build:bundler`, each running `wasm-pack build --release --target {web,nodejs,bundler} --out-dir dist/{web,node,bundler} --out-name centaur-technical-indicators` then `rm -f dist/<target>/.gitignore`. Keep `--out-name centaur-technical-indicators` consistent and preserve the post-build `.gitignore` cleanup (load-bearing for packaging). CI runs the three `wasm-pack` commands directly, without that cleanup step.
-4. `node --test` — all JS tests pass (auto-discovers `test/**/*.test.js`). `npm test` runs `npm run build && node --test`.
+3. `npm run build` — builds all three WASM targets (web / node / bundler).
+4. `node --test` — all JS tests pass (`npm test` runs build then `node --test`).
 
-## When to stop and report
-Stop and report rather than guess or work around an obstacle when:
-- the task is ambiguous, contradictory, or underspecified;
-- completing it would require a forbidden or breaking change (public API, semantics, output ordering, warmup behavior) without explicit approval;
-- a required pre-PR gate cannot be run, or fails for reasons outside your change.
+## Branch & commit conventions
+
+- Never commit directly to `main`; branch first. PRs target `main`.
+- Stacked-PR branches use `pr/<n>-<slug>` (e.g. `pr/7-cjs-export`); letter-suffixed
+  sub-PRs are allowed (`pr/6b-doc-consolidation`). Before a PR number exists, branch
+  `<type>/<slug>` (conventional-commit type) and rename once the PR is opened.
+  `release/<x.y.z>` for release branches.
+- Commit subjects use a conventional-commit prefix, under 72 characters; reference
+  PR/issue numbers where applicable.
+- End every agent-authored commit with:
+
+      Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+## Stop-and-report
+
+**Never guess or assume.** If information is missing, the task is ambiguous, or two
+implementations are plausible, **stop and ask for input** before proceeding — don't
+pick one and run. Beyond that, stop and report — never work around, paper over, or
+invent a way past — when:
+
+- a pre-PR gate fails for a reason outside your change, or a test expectation shifts
+  in a way you can't explain;
+- completing the task would require a forbidden or breaking change (public API,
+  semantics, output ordering, warmup) without explicit approval;
+- the brief or instructions conflict with the repo's actual state.
 
 Surface the blocker; do not invent a way past it.
 
-## Worktrees and isolation
-- Do one task per branch (use a `git worktree` for parallel work); never operate directly on `main`.
-- Keep concurrent tasks file-disjoint so parallel runs don't collide.
+## Worktree & isolation
 
-## Docs to review before coding
-- `CONTRIBUTING.md`
-- `CLAUDE.md`
+For parallel or batched work: one task per git worktree (never operate directly on
+`main`); keep concurrent tasks file-disjoint so parallel runs don't collide; when two
+touch the same files, rebase the later on its predecessor before merging.
 
-## PR expectations for agents
-- Keep PRs focused and minimal.
-- Summarize what the agent changed and what was manually verified.
-- Include command output for the required quality gates.
-- Explicitly note the `CHANGELOG.md` entry added or updated.
+## Changelog coupling
 
-### Required PR summary format
-Use this structure in PR descriptions/comments:
+Every user-facing change adds a bullet under the existing `## [Unreleased]` heading in
+`CHANGELOG.md` (Keep a Changelog categories: Added / Changed / Deprecated / Removed /
+Fixed / Security); name the concrete artifact. Don't add a second `[Unreleased]`
+heading. Formatting-only or non-user-facing changes (incl. docs like this file) are
+exempt — note the exception in the PR.
 
-1. `Summary`: what changed and why.
-2. `Scope`: files/modules touched and what was intentionally left untouched.
-3. `Compatibility`: any user-facing behavior/API/TypeScript-definition (`index.d.ts`) impact, with migration notes if applicable.
-4. `Validation`: paste the verbatim output of each pre-PR gate — `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `npm run build`, and `node --test`.
-5. `Changelog`: the exact `CHANGELOG.md` entry added/updated (or note why exempt).
-6. `Flagged items`: anything unresolved, intentionally skipped, or deviating from these conventions (including any blocked gate). Write "None" if there are none.
+## CI policy
+
+Keep CI dependency-light: prefer native cargo/npm commands; no third-party GitHub
+Actions for toolchain setup or caching without explicit approval.
+
+## PR / completion report
+
+Use this structure:
+
+1. **Summary** — what changed and why.
+2. **Scope** — files/modules touched, and what was deliberately left untouched.
+3. **Compatibility** — user-facing behavior/API/TypeScript-definition (`index.d.ts`) impact, or "N/A".
+4. **Validation** — pasted output of the four pre-PR gates.
+5. **Changelog** — the exact `CHANGELOG.md` entry added/updated (or "exempt — non-user-facing").
+6. **Benchmarks** — affected suites + regression/improvement summary, or "N/A".
+
+Plus, required: each named acceptance test with its pass output verbatim (incl. the
+decisive test), and anything flagged — out-of-scope issues noticed, concerns,
+blockers. Justify any deviation from the brief here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,17 @@
 # CLAUDE.md
 
-This repository's canonical agent guidance lives in [`AGENTS.md`](./AGENTS.md) —
-contribution requirements, change-scope discipline, backward-compatibility
-rules, and the pre-PR quality gates. See it (and `CONTRIBUTING.md`) before
-making changes.
+Claude Code notes for this repository. **[`AGENTS.md`](./AGENTS.md) is canonical**
+for every standing convention — how work arrives, the pre-PR gates, branch/commit/PR
+conventions, change-scope discipline, stop-and-report, and changelog coupling. Read
+it before making changes; this file adds only Claude-Code specifics and does not
+repeat it.
+
+- **Never guess.** If information is missing or the task is ambiguous, stop and ask
+  for input — don't assume.
+- **Effort:** if your task is a slice brief, set the session to its `effort` with
+  `/effort <level>` before starting.
+- **Plan before auto-editing:** for non-trivial work, plan in plan mode before
+  auto-applying changes.
+- **Read-order:** your brief is self-contained — see `AGENTS.md` → "How work
+  arrives." Don't pull in the implementation plan or project spec to execute a
+  brief; if you hit a gap, stop and ask.


### PR DESCRIPTION
Makes `AGENTS.md` and `CLAUDE.md` in this repository fully self-contained — everything a coding agent needs is in-repo, with no references to any workspace-level file and no machine or personal paths (so a cloner gets working guidance, and nothing leaks).

- Self-contained header, plus a never-guess rule: missing info or ambiguity means stop and ask.
- Read-order: an implementer works only from its self-contained slice brief.
- CTI libraries share a harmonized structure; companion and site repos use a trimmed self-contained form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
